### PR TITLE
feat: add cascade publish support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish to NPM
 
 on:
+  repository_dispatch:
+    types: [cascade-publish]
   workflow_dispatch:
     inputs:
       version-type:
@@ -21,6 +23,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.event_name == 'repository_dispatch' && 'cascade-update' || format('publish-{0}', github.ref) }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write
@@ -28,8 +34,18 @@ permissions:
 
 jobs:
   publish:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     uses: abofs/stonyx-workflows/.github/workflows/npm-publish.yml@main
     with:
       version-type: ${{ github.event.inputs.version-type }}
       custom-version: ${{ github.event.inputs.custom-version }}
+      cascade-source: ${{ github.event.client_payload.source_package || '' }}
+    secrets: inherit
+
+  cascade:
+    needs: publish
+    uses: abofs/stonyx-workflows/.github/workflows/cascade.yml@main
+    with:
+      package-name: ${{ needs.publish.outputs.package-name }}
+      published-version: ${{ needs.publish.outputs.published-version }}
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -37,19 +37,22 @@
   },
   "homepage": "https://github.com/abofs/stonyx-orm#readme",
   "dependencies": {
-    "stonyx": "file:../stonyx",
-    "@stonyx/events": "file:../stonyx-events",
-    "@stonyx/cron": "file:../stonyx-cron"
+    "stonyx": "0.2.3-beta.0",
+    "@stonyx/events": "0.1.1-beta.1",
+    "@stonyx/cron": "0.2.1-beta.0"
   },
   "peerDependencies": {
     "mysql2": "^3.0.0"
   },
   "peerDependenciesMeta": {
-    "mysql2": { "optional": true }
+    "mysql2": {
+      "optional": true
+    }
   },
   "devDependencies": {
-    "@stonyx/rest-server": "file:../stonyx-rest-server",
-    "@stonyx/utils": "file:../stonyx-utils",
+    "@stonyx/rest-server": "0.2.1-beta.1",
+    "@stonyx/utils": "0.2.3-beta.2",
     "qunit": "^2.24.1",
     "sinon": "^21.0.0"
-  }}
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,24 +9,24 @@ importers:
   .:
     dependencies:
       '@stonyx/cron':
-        specifier: file:../stonyx-cron
-        version: file:../stonyx-cron
+        specifier: 0.2.1-beta.0
+        version: 0.2.1-beta.0
       '@stonyx/events':
-        specifier: file:../stonyx-events
-        version: file:../stonyx-events
+        specifier: 0.1.1-beta.1
+        version: 0.1.1-beta.1
       mysql2:
         specifier: ^3.0.0
         version: 3.16.3
       stonyx:
-        specifier: file:../stonyx
-        version: file:../stonyx
+        specifier: 0.2.3-beta.0
+        version: 0.2.3-beta.0
     devDependencies:
       '@stonyx/rest-server':
-        specifier: file:../stonyx-rest-server
-        version: file:../stonyx-rest-server
+        specifier: 0.2.1-beta.1
+        version: 0.2.1-beta.1
       '@stonyx/utils':
-        specifier: file:../stonyx-utils
-        version: file:../stonyx-utils
+        specifier: 0.2.3-beta.2
+        version: 0.2.3-beta.2
       qunit:
         specifier: ^2.24.1
         version: 2.24.1
@@ -45,17 +45,17 @@ packages:
   '@sinonjs/samsam@8.0.3':
     resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
 
-  '@stonyx/cron@file:../stonyx-cron':
-    resolution: {directory: ../stonyx-cron, type: directory}
+  '@stonyx/cron@0.2.1-beta.0':
+    resolution: {integrity: sha512-sf90QENd6rAPhW1+lFxC5hxVaPYCrFkZc/6FwU+mBmkTQeL1sk7oVX/46MjlHpPh+bIVRys1mcKkTVPsweALZQ==}
 
-  '@stonyx/events@file:../stonyx-events':
-    resolution: {directory: ../stonyx-events, type: directory}
+  '@stonyx/events@0.1.1-beta.1':
+    resolution: {integrity: sha512-6K4cPksZMhUZ0RfYTA9PIACkZ1JPbEaSwyt7X6XBgxFHxG9oC7mRqVxE1bF1U5hmL29loiE7hHgMwFLyJ/Uhbw==}
 
-  '@stonyx/rest-server@file:../stonyx-rest-server':
-    resolution: {directory: ../stonyx-rest-server, type: directory}
+  '@stonyx/rest-server@0.2.1-beta.1':
+    resolution: {integrity: sha512-lbrL3s9XrZm/pDYRlD7w97fgjuacZmmgmErvbQw0xlvCAVMHx9FqVxurAVCeJEhIQzn7Phn2pWF1f3gRrfLuyw==}
 
-  '@stonyx/utils@file:../stonyx-utils':
-    resolution: {directory: ../stonyx-utils, type: directory}
+  '@stonyx/utils@0.2.3-beta.2':
+    resolution: {integrity: sha512-GsKNqYPtf2SpvcDTvWB+TBee7uzDeLWXjXDHwSQR/Y6wTMbjH6YtU4gaITB19P74vGe/4Xwpuf+3UTeM0/3PjQ==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -389,9 +389,11 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  stonyx@file:../stonyx:
-    resolution: {directory: ../stonyx, type: directory}
-    hasBin: true
+  stonyx@0.2.2:
+    resolution: {integrity: sha512-X37/2R2YklI+CX4wKHckPg2pFmOL1hk0CwOMvn7E00sE+8JjhmbHvAeTI+0t50kufBsXKREPX3FBHVUd4Yi4Fw==}
+
+  stonyx@0.2.3-beta.0:
+    resolution: {integrity: sha512-1S5BpvoVryCX75LqwuiiRv3Gdpe+uAtNHyWVnyu3VjaHi19fLCtQDMUKVxVOMcQTslwd1zkxMNKDc4SHKFRHIw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -449,21 +451,21 @@ snapshots:
       '@sinonjs/commons': 3.0.1
       type-detect: 4.1.0
 
-  '@stonyx/cron@file:../stonyx-cron':
+  '@stonyx/cron@0.2.1-beta.0':
     dependencies:
-      stonyx: file:../stonyx
+      stonyx: 0.2.2
 
-  '@stonyx/events@file:../stonyx-events': {}
+  '@stonyx/events@0.1.1-beta.1': {}
 
-  '@stonyx/rest-server@file:../stonyx-rest-server':
+  '@stonyx/rest-server@0.2.1-beta.1':
     dependencies:
       cors: 2.8.6
       express: 5.2.1
-      stonyx: file:../stonyx
+      stonyx: 0.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@stonyx/utils@file:../stonyx-utils': {}
+  '@stonyx/utils@0.2.3-beta.2': {}
 
   accepts@2.0.0:
     dependencies:
@@ -832,7 +834,11 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  stonyx@file:../stonyx:
+  stonyx@0.2.2:
+    dependencies:
+      node-chronicle: 0.2.0
+
+  stonyx@0.2.3-beta.0:
     dependencies:
       node-chronicle: 0.2.0
 


### PR DESCRIPTION
## Summary
- Add `repository_dispatch` trigger and cascade job to `publish.yml` for automated downstream dependency updates
- Replace `file:../` references in `package.json` with real npm versions (latest beta pins)
- Regenerate `pnpm-lock.yaml` with npm registry versions

## Test plan
- [ ] `pnpm install` succeeds with npm versions
- [ ] CI tests pass on the PR
- [ ] Workflow YAML is valid (no syntax errors in Actions tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)