### PR TITLE
Support null attribute clearing

### DIFF
--- a/src/model-property.js
+++ b/src/model-property.js
@@ -22,8 +22,8 @@ export default class ModelProperty {
       return this._value = newValue;
     }
 
-    if (newValue === undefined || newValue === null) return;
+    if (newValue === undefined) return;
 
-    this._value = Orm.instance.transforms[this.type](newValue);
+    this._value = newValue === null ? null : Orm.instance.transforms[this.type](newValue);
   }
 }

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -71,8 +71,8 @@ export default class Serializer {
       const handler = model[key];
       const data = query(rawData, pathPrefix, subPath);
 
-      // Ignore null/undefined values on updates (TODO: What if we want it set to null?)
-      if ((data === null || data === undefined) && options.update) continue;
+      // Skip fields not present in the update payload (undefined = not provided)
+      if (data === undefined && options.update) continue;
 
       // Relationship handling
       if (typeof handler === 'function') {

--- a/test/integration/orm-test.js
+++ b/test/integration/orm-test.js
@@ -228,6 +228,20 @@ module('[Integration] ORM', function(hooks) {
       animal.size = 'medium';
     });
 
+    test('updateRecord with null clears the field', function(assert) {
+      const owner = store.get('owner', 'bob');
+
+      assert.equal(owner.age, 44, 'age starts as 44');
+
+      updateRecord(owner, { age: null });
+
+      assert.strictEqual(owner.age, null, 'age is null after updateRecord with null');
+      assert.strictEqual(owner.__data.age, null, '__data.age is null');
+
+      // Revert change
+      owner.age = 44;
+    });
+
     test('db saves correct serialized data and relationships', async function(assert) {
       await Orm.db.save();
       parsedFileData = await readFile(config.orm.db.file, { json: true });
@@ -430,6 +444,30 @@ module('[Integration] ORM', function(hooks) {
       assert.equal(data.type, 'animal');
       assert.equal(data.id, targetId);
       assert.equal(data.attributes.size, 'small');
+    });
+
+    test('PATCH with null attribute clears the field', async function(assert) {
+      const owner = store.get('owner', 'bob');
+
+      assert.equal(owner.age, 44, 'age starts as 44');
+
+      const response = await fetch(`${endpoint}/owners/bob`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          data: {
+            type: 'owner',
+            id: 'bob',
+            attributes: { age: null }
+          }
+        })
+      });
+
+      assert.equal(response.status, 200);
+      assert.strictEqual(owner.age, null, 'age is null after PATCH with null');
+
+      // Revert change
+      owner.age = 44;
     });
 
     test('delete call for schema records work as expected', async function(assert) {


### PR DESCRIPTION
## Summary
- `updateRecord()` and PATCH can now set attributes to `null`
- `ModelProperty` stores null instead of silently ignoring it
- Serializer skips only `undefined` (not-present) fields on updates, allowing explicit `null` through

## Dependencies
- Requires @stonyx/utils 0.2.3-beta.5+ (`get()` returning `undefined` for missing paths)

## Test plan
- [x] Integration test: `updateRecord` with null clears the field
- [x] Integration test: PATCH with null attribute clears the field
- [x] CI passing