### PR TITLE
Change Model.memory default from true to false

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -128,7 +128,7 @@ export default class Orm {
     // Wire up memory resolver so store.find() can check model memory flags
     Orm.store._memoryResolver = (modelName) => {
       const { modelClass } = this.getRecordClasses(modelName);
-      return modelClass?.memory !== false;
+      return modelClass?.memory === true;
     };
 
     // Wire up MySQL reference for on-demand queries from store.find()/findAll()

--- a/src/model.js
+++ b/src/model.js
@@ -4,12 +4,12 @@ export default class Model {
   /**
    * Controls whether records of this model are loaded into memory on startup.
    *
-   * - true  → loaded on boot, kept in store (default for backward compatibility)
-   * - false → never cached; find() always queries MySQL
+   * - true  → loaded on boot, kept in store
+   * - false → never cached; find() always queries MySQL (default)
    *
-   * Override in subclass: static memory = false;
+   * Override in subclass: static memory = true;
    */
-  static memory = true;
+  static memory = false;
   static pluralName = undefined;
 
   id = attr('number');

--- a/src/mysql/schema-introspector.js
+++ b/src/mysql/schema-introspector.js
@@ -70,7 +70,7 @@ export function introspectModels() {
       columns,
       foreignKeys,
       relationships,
-      memory: modelClass.memory !== false, // default true for backward compat
+      memory: modelClass.memory === true,
     };
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -136,7 +136,7 @@ export default class Store {
    */
   _isMemoryModel(modelName) {
     if (this._memoryResolver) return this._memoryResolver(modelName);
-    return true; // default to memory if resolver not set yet
+    return false; // default to non-memory if resolver not set yet
   }
 
   set(key, value) {

--- a/test/unit/model-memory-test.js
+++ b/test/unit/model-memory-test.js
@@ -5,32 +5,32 @@ const { module, test } = QUnit;
 
 module('[Unit] Model.memory — Static Flag', function() {
 
-  test('Model base class has memory: true by default', function(assert) {
-    assert.strictEqual(Model.memory, true, 'default is memory: true for backward compat');
+  test('Model base class has memory: false by default', function(assert) {
+    assert.strictEqual(Model.memory, false, 'default is memory: false');
   });
 
-  test('subclass inherits memory: true', function(assert) {
-    class Session extends Model {}
+  test('subclass inherits memory: false', function(assert) {
+    class Alert extends Model {}
 
-    assert.strictEqual(Session.memory, true, 'subclass inherits memory: true');
+    assert.strictEqual(Alert.memory, false, 'subclass inherits memory: false');
   });
 
-  test('subclass can override memory to false', function(assert) {
-    class Alert extends Model {
-      static memory = false;
+  test('subclass can override memory to true', function(assert) {
+    class Session extends Model {
+      static memory = true;
     }
 
-    assert.strictEqual(Alert.memory, false, 'subclass overrides to memory: false');
+    assert.strictEqual(Session.memory, true, 'subclass overrides to memory: true');
   });
 
   test('overriding one subclass does not affect base or other subclasses', function(assert) {
-    class MemoryModel extends Model {}
-    class NoMemoryModel extends Model {
-      static memory = false;
+    class NoMemoryModel extends Model {}
+    class MemoryModel extends Model {
+      static memory = true;
     }
 
-    assert.strictEqual(Model.memory, true, 'base class unchanged');
-    assert.strictEqual(MemoryModel.memory, true, 'other subclass unchanged');
-    assert.strictEqual(NoMemoryModel.memory, false, 'override only affects its own class');
+    assert.strictEqual(Model.memory, false, 'base class unchanged');
+    assert.strictEqual(NoMemoryModel.memory, false, 'other subclass unchanged');
+    assert.strictEqual(MemoryModel.memory, true, 'override only affects its own class');
   });
 });

--- a/test/unit/mysql/mysql-db-memory-flag-test.js
+++ b/test/unit/mysql/mysql-db-memory-flag-test.js
@@ -56,7 +56,7 @@ function mockOrmModule(memoryModels = {}) {
     default: {
       instance: {
         getRecordClasses(modelName) {
-          const memory = memoryModels[modelName] !== undefined ? memoryModels[modelName] : true;
+          const memory = memoryModels[modelName] !== undefined ? memoryModels[modelName] : false;
           return { modelClass: { memory } };
         }
       }

--- a/test/unit/store-find-test.js
+++ b/test/unit/store-find-test.js
@@ -57,12 +57,18 @@ module('[Unit] Store.find', function(hooks) {
     assert.strictEqual(record.name, 'Alice', 'falls back to in-memory store');
   });
 
-  test('find defaults to memory:true when no resolver set', async function(assert) {
+  test('find defaults to memory:false when no resolver set (queries MySQL)', async function(assert) {
     const store = createStore();
     store._memoryResolver = null;
 
+    const mockRecord = { id: 1, name: 'Alice' };
+    store._mysqlDb = {
+      findRecord: sinon.stub().resolves(mockRecord)
+    };
+
     const record = await store.find('user', 1);
-    assert.strictEqual(record.name, 'Alice', 'defaults to memory lookup');
+    assert.ok(store._mysqlDb.findRecord.calledOnce, 'queries MySQL when no resolver');
+    assert.strictEqual(record, mockRecord, 'returns MySQL result');
   });
 });
 
@@ -201,10 +207,10 @@ module('[Unit] Store._isMemoryModel', function(hooks) {
     assert.notOk(store._isMemoryModel('alert'), 'memory:false model recognized');
   });
 
-  test('defaults to true when no resolver set', function(assert) {
+  test('defaults to false when no resolver set', function(assert) {
     const store = createStore();
     store._memoryResolver = null;
 
-    assert.ok(store._isMemoryModel('anything'), 'defaults to memory:true');
+    assert.notOk(store._isMemoryModel('anything'), 'defaults to memory:false');
   });
 });


### PR DESCRIPTION
## Summary

Switches the default `Model.memory` flag from `true` to `false` so that models are queried on-demand from MySQL by default instead of being preloaded into memory on startup. Models that need in-memory caching must now explicitly opt in with `static memory = true`.

## Changes

- `Model.memory` base class default changed from `true` to `false`
- Memory resolver in `Orm.init()` uses `=== true` instead of `!== false` to match new default
- `Store._isMemoryModel()` fallback (no resolver) returns `false` instead of `true`
- Schema introspector memory flag uses `=== true` instead of `!== false`
- All related tests updated to reflect the new default behavior