### PR TITLE
Fix FK reference naming and slash-in-table-name bugs in MySQL migration generator

### DIFF
--- a/src/belongs-to.js
+++ b/src/belongs-to.js
@@ -11,7 +11,7 @@ export default function belongsTo(modelName) {
   const pendingHasManyQueue = relationships.get('pending');
   const pendingBelongsToQueue = relationships.get('pendingBelongsTo');
 
-  return (sourceRecord, rawData, options) => {
+  const fn = (sourceRecord, rawData, options) => {
     if (!rawData) return null;
 
     const { __name: sourceModelName } = sourceRecord.__model;
@@ -60,4 +60,7 @@ export default function belongsTo(modelName) {
 
     return output;
   }
+
+  fn.__relatedModelName = modelName;
+  return fn;
 }

--- a/src/has-many.js
+++ b/src/has-many.js
@@ -16,7 +16,7 @@ export default function hasMany(modelName) {
   const globalRelationships = relationships.get('global');
   const pendingRelationships = relationships.get('pending');
 
-  return (sourceRecord, rawData, options) => {
+  const fn = (sourceRecord, rawData, options) => {
     const { __name: sourceModelName } = sourceRecord.__model;
     const relationshipId = sourceRecord.id;
     const relationship = getRelationships('hasMany', sourceModelName, modelName, relationshipId);
@@ -58,4 +58,7 @@ export default function hasMany(modelName) {
 
     return output;
   }
+
+  fn.__relatedModelName = modelName;
+  return fn;
 }

--- a/src/mysql/schema-introspector.js
+++ b/src/mysql/schema-introspector.js
@@ -7,11 +7,16 @@ import { dbKey } from '../db.js';
 function getRelationshipInfo(property) {
   if (typeof property !== 'function') return null;
   const fnStr = property.toString();
+  const modelName = property.__relatedModelName || null;
 
-  if (fnStr.includes(`getRelationships('belongsTo',`)) return 'belongsTo';
-  if (fnStr.includes(`getRelationships('hasMany',`)) return 'hasMany';
+  if (fnStr.includes(`getRelationships('belongsTo',`)) return { type: 'belongsTo', modelName };
+  if (fnStr.includes(`getRelationships('hasMany',`)) return { type: 'hasMany', modelName };
 
   return null;
+}
+
+function sanitizeTableName(name) {
+  return name.replace(/\//g, '_');
 }
 
 export function introspectModels() {
@@ -34,12 +39,12 @@ export function introspectModels() {
     for (const [key, property] of Object.entries(model)) {
       if (key.startsWith('__')) continue;
 
-      const relType = getRelationshipInfo(property);
+      const relInfo = getRelationshipInfo(property);
 
-      if (relType === 'belongsTo') {
-        relationships.belongsTo[key] = true;
-      } else if (relType === 'hasMany') {
-        relationships.hasMany[key] = true;
+      if (relInfo?.type === 'belongsTo') {
+        relationships.belongsTo[key] = relInfo.modelName;
+      } else if (relInfo?.type === 'hasMany') {
+        relationships.hasMany[key] = relInfo.modelName;
       } else if (property?.constructor?.name === 'ModelProperty') {
         if (key === 'id') {
           idType = property.type;
@@ -50,17 +55,16 @@ export function introspectModels() {
     }
 
     // Build foreign keys from belongsTo relationships
-    for (const relName of Object.keys(relationships.belongsTo)) {
-      const modelName = camelCaseToKebabCase(relName);
+    for (const [relName, targetModelName] of Object.entries(relationships.belongsTo)) {
       const fkColumn = `${relName}_id`;
       foreignKeys[fkColumn] = {
-        references: getPluralName(modelName),
+        references: sanitizeTableName(getPluralName(targetModelName)),
         column: 'id',
       };
     }
 
     schemas[name] = {
-      table: getPluralName(name),
+      table: sanitizeTableName(getPluralName(name)),
       idType,
       columns,
       foreignKeys,
@@ -73,7 +77,8 @@ export function introspectModels() {
 }
 
 export function buildTableDDL(name, schema, allSchemas = {}) {
-  const { table, idType, columns, foreignKeys } = schema;
+  const { idType, columns, foreignKeys } = schema;
+  const table = sanitizeTableName(schema.table);
   const lines = [];
 
   // Primary key
@@ -100,7 +105,8 @@ export function buildTableDDL(name, schema, allSchemas = {}) {
 
   // Foreign key constraints
   for (const [fkCol, fkDef] of Object.entries(foreignKeys)) {
-    lines.push(`  FOREIGN KEY (\`${fkCol}\`) REFERENCES \`${fkDef.references}\`(\`${fkDef.column}\`) ON DELETE SET NULL`);
+    const refTable = sanitizeTableName(fkDef.references);
+    lines.push(`  FOREIGN KEY (\`${fkCol}\`) REFERENCES \`${refTable}\`(\`${fkDef.column}\`) ON DELETE SET NULL`);
   }
 
   return `CREATE TABLE IF NOT EXISTS \`${table}\` (\n${lines.join(',\n')}\n)`;
@@ -130,8 +136,8 @@ export function getTopologicalOrder(schemas) {
     if (!schema) return;
 
     // Visit dependencies (belongsTo targets) first
-    for (const relName of Object.keys(schema.relationships.belongsTo)) {
-      visit(camelCaseToKebabCase(relName));
+    for (const targetModelName of Object.values(schema.relationships.belongsTo)) {
+      visit(targetModelName);
     }
 
     order.push(name);

--- a/test/unit/mysql/schema-introspector-test.js
+++ b/test/unit/mysql/schema-introspector-test.js
@@ -19,21 +19,21 @@ function smartLockSchemas() {
       idType: 'string',
       columns: {},
       foreignKeys: { user_id: { references: 'users', column: 'id' } },
-      relationships: { belongsTo: { user: true }, hasMany: { 'access-link': true } },
+      relationships: { belongsTo: { user: 'user' }, hasMany: { 'access-link': true } },
     },
     session: {
       table: 'sessions',
       idType: 'string',
       columns: { expiration: 'INT', selectedDevice: 'VARCHAR(255)' },
       foreignKeys: { user_id: { references: 'users', column: 'id' } },
-      relationships: { belongsTo: { user: true }, hasMany: {} },
+      relationships: { belongsTo: { user: 'user' }, hasMany: {} },
     },
     'access-link': {
       table: 'access-links',
       idType: 'string',
       columns: { expiration: 'INT', active: 'TINYINT(1)' },
       foreignKeys: { device_id: { references: 'devices', column: 'id' } },
-      relationships: { belongsTo: { device: true }, hasMany: {} },
+      relationships: { belongsTo: { device: 'device' }, hasMany: {} },
     },
   };
 }
@@ -53,7 +53,7 @@ function numericPkSchemas() {
       idType: 'number',
       columns: { title: 'VARCHAR(255)' },
       foreignKeys: { author_id: { references: 'authors', column: 'id' } },
-      relationships: { belongsTo: { author: true }, hasMany: {} },
+      relationships: { belongsTo: { author: 'author' }, hasMany: {} },
     },
   };
 }
@@ -167,5 +167,77 @@ module('[Unit] Migration Generator — diffSnapshots', function() {
     assert.true(diff.hasChanges, 'should detect changes');
     assert.strictEqual(diff.addedForeignKeys.length, 1, 'should have 1 added FK');
     assert.strictEqual(diff.addedForeignKeys[0].column, 'user_id', 'FK column is user_id');
+  });
+});
+
+module('[Unit] Schema Introspector — FK reference naming (Bug #1)', function() {
+
+  test('topological order resolves correctly when belongsTo property names differ from model names', function(assert) {
+    const schemas = {
+      game: {
+        table: 'games',
+        idType: 'number',
+        columns: {},
+        foreignKeys: { homeStanding_id: { references: 'standings', column: 'id' } },
+        relationships: { belongsTo: { homeStanding: 'standing', awayStanding: 'standing' }, hasMany: {} },
+      },
+      standing: {
+        table: 'standings',
+        idType: 'number',
+        columns: { score: 'INT' },
+        foreignKeys: {},
+        relationships: { belongsTo: {}, hasMany: {} },
+      },
+    };
+
+    const order = getTopologicalOrder(schemas);
+    const gameIdx = order.indexOf('game');
+    const standingIdx = order.indexOf('standing');
+
+    assert.true(standingIdx >= 0, 'standing should be in the order');
+    assert.true(gameIdx >= 0, 'game should be in the order');
+    assert.true(standingIdx < gameIdx, 'standing (dependency) should come before game');
+  });
+});
+
+module('[Unit] Schema Introspector — slash in table names (Bug #2)', function() {
+
+  test('buildTableDDL converts slashes to underscores in table names for subdirectory models', function(assert) {
+    const schemas = {
+      'game-stats/standing': {
+        table: 'game-stats/standings',
+        idType: 'number',
+        columns: { score: 'INT' },
+        foreignKeys: {},
+        relationships: { belongsTo: {}, hasMany: {} },
+      },
+    };
+    const ddl = buildTableDDL('game-stats/standing', schemas['game-stats/standing'], schemas);
+
+    assert.true(ddl.includes('game-stats_standings'), 'table name should use underscores instead of slashes');
+    assert.false(ddl.includes('game-stats/standings'), 'table name should not contain slashes');
+  });
+
+  test('buildTableDDL converts slashes to underscores in FK REFERENCES for subdirectory models', function(assert) {
+    const schemas = {
+      game: {
+        table: 'games',
+        idType: 'number',
+        columns: {},
+        foreignKeys: { homeStanding_id: { references: 'game-stats/standings', column: 'id' } },
+        relationships: { belongsTo: { homeStanding: 'game-stats/standing' }, hasMany: {} },
+      },
+      'game-stats/standing': {
+        table: 'game-stats/standings',
+        idType: 'number',
+        columns: { score: 'INT' },
+        foreignKeys: {},
+        relationships: { belongsTo: {}, hasMany: {} },
+      },
+    };
+    const ddl = buildTableDDL('game', schemas.game, schemas);
+
+    assert.true(ddl.includes('REFERENCES `game-stats_standings`'), 'FK REFERENCES should use underscores instead of slashes');
+    assert.false(ddl.includes('REFERENCES `game-stats/standings`'), 'FK REFERENCES should not contain slashes');
   });
 });


### PR DESCRIPTION
## Summary

Fixes two bugs in the MySQL migration generator / schema introspector that caused incorrect `REFERENCES` clauses and invalid table names for subdirectory models.

## Changes

- **FK reference naming**: `belongsTo` and `hasMany` now attach `__relatedModelName` metadata to their returned functions. The schema introspector reads this metadata to resolve the actual target model name, instead of incorrectly deriving it from the property name (e.g., `homeStanding` → `home-standing` instead of the actual `game-stats/standing`). This also fixes `getTopologicalOrder` which had the same property-name-derivation bug.

- **Slash in table names**: Added `sanitizeTableName()` which replaces `/` with `_` in generated MySQL table names and FK references. Applied both in `introspectModels()` (upstream) and defensively in `buildTableDDL()` (downstream), so subdirectory models like `game-stats/standing` produce table names like `game-stats_standings` instead of `game-stats/standings`.

- **Tests**: 3 new unit tests covering both bugs (topological ordering with mismatched property/model names, slash sanitization in table names, slash sanitization in FK REFERENCES). All 324 tests pass.