### PR TITLE
fix: add explicit files whitelist for npm publish safety

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,10 @@
-# tests
-test/
-
-# config
-.nvmrc
-# git
 .git
+.env
+.npmrc
+.claude/
+.github/
+test/
+scripts/
+*.log
+.nvmrc
+.gitignore

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
   "contributors": [
     "Stone Costa <stone.costa@synamicd.com>"
   ],
+  "files": [
+    "src",
+    "config",
+    "README.md"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
## Summary
- Add `"files"` field to `package.json` whitelisting only `src/`, `config/`, and `README.md` for npm publish
- Replace existing `.npmignore` (missed loose root test files like `test-events-setup.js`, `test-hooks-manual.js`, `test-hooks-with-logging.js`, and the `scripts/` directory) with comprehensive exclusions covering `.env`, `.npmrc`, `.claude/`, `.github/`, `test/`, `scripts/`, `*.log`, `.nvmrc`, and `.gitignore`
- Verified via `npm pack --dry-run` that only intended files are included in the tarball

Closes #31

## Test plan
- [x] `npm pack --dry-run` shows only `src/`, `config/`, `README.md`, `LICENSE.md`, and `package.json`
- [ ] Publish a beta to verify the tarball contents in the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)