### PR TITLE
fix: context review cleanup after docs restructure

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -4,9 +4,9 @@ The ORM provides a powerful middleware-based hook system that allows custom logi
 
 ## Architecture
 
-**Hook Registry**: [src/hooks.js](src/hooks.js) - Stores before/after hooks in Maps
-**Integration**: [src/orm-request.js](src/orm-request.js) - `_withHooks()` wrapper executes hooks
-**Exports**: [src/index.js](src/index.js) - Exports `beforeHook`, `afterHook`, `clearHook`, `clearAllHooks`
+**Hook Registry**: [src/hooks.js](../src/hooks.js) - Stores before/after hooks in Maps
+**Integration**: [src/orm-request.js](../src/orm-request.js) - `_withHooks()` wrapper executes hooks
+**Exports**: [src/index.js](../src/index.js) - Exports `beforeHook`, `afterHook`, `clearHook`, `clearAllHooks`
 
 ## API
 

--- a/docs/improvements.md
+++ b/docs/improvements.md
@@ -85,40 +85,15 @@ The codebase is well-structured with clear separation of concerns and consistent
 
 ## Low Priority
 
-### [L1] Documentation references non-existent files
-- **Category:** Stale Docs
-- **Files:** `.claude/index.md` (L38-39), `.claude/personal/outline.md` (L1107)
-- **Problem:** The `.claude/index.md` references `src/include-parser.js` and `src/include-collector.js` which don't exist — include parsing is inline in `src/orm-request.js`. The outline references `stonyx-bootstrap.cjs` which doesn't exist.
-- **Suggestion:** Remove the `include-parser.js` and `include-collector.js` references from `.claude/index.md` and the `stonyx-bootstrap.cjs` reference from the outline. Update the architecture section to point to `src/orm-request.js` for include logic.
-- **Impact:** Prevents confusion when navigating docs.
+~~### [L1] Documentation references non-existent files~~ **RESOLVED** — `.claude/index.md` and `.claude/personal/outline.md` deleted during docs restructure.
 
-### [L2] Outdated version in outline doc
-- **Category:** Stale Docs
-- **Files:** `.claude/personal/outline.md` (L1076)
-- **Problem:** Lists version as `0.1.0` but `package.json` shows `0.2.1-beta.1`.
-- **Suggestion:** Update or remove the version reference. Since `package.json` is the source of truth, the docs shouldn't duplicate it.
-- **Impact:** Minor — prevents stale version confusion.
+~~### [L2] Outdated version in outline doc~~ **RESOLVED** — `.claude/personal/outline.md` deleted during docs restructure.
 
-### [L3] Outline docs missing `./commands` and `./hooks` package exports
-- **Category:** Stale Docs
-- **Files:** `.claude/personal/outline.md` (L884-889)
-- **Problem:** The package.json `exports` section in the outline doc only shows `"."` and `"./db"`, but the actual `package.json` also exports `"./migrate"`, `"./commands"`, and `"./hooks"`.
-- **Suggestion:** Update the outline's package.json section to match the actual exports.
-- **Impact:** Minor — ensures docs reflect the full public API surface.
+~~### [L3] Outline docs missing `./commands` and `./hooks` package exports~~ **RESOLVED** — `.claude/personal/outline.md` deleted during docs restructure.
 
-### [L4] Outline references old event-based system
-- **Category:** Stale Docs
-- **Files:** `.claude/index.md` (L204)
-- **Problem:** States `@stonyx/events - Pub/sub event system (optional, not used for hooks)`. However, `@stonyx/events` is imported and `setup(eventNames)` is called in `src/main.js` (L91). The events are set up but the hooks system uses its own registry. This is confusing — events are initialized but the hooks use a separate middleware pattern.
-- **Suggestion:** Clarify that `@stonyx/events` is still initialized for event names during ORM setup, but the actual hook dispatch uses the middleware-based system in `src/hooks.js`.
-- **Impact:** Reduces confusion about the relationship between `@stonyx/events` and the hooks system.
+~~### [L4] Outline references old event-based system~~ **RESOLVED** — `.claude/index.md` deleted during docs restructure.
 
-### [L5] Manual test scripts in project root
-- **Category:** Dead Code
-- **Files:** `test-hooks-with-logging.js`, `test-events-setup.js`, `test-hooks-manual.js`
-- **Problem:** Three manual test scripts remain in the project root from the hooks implementation. They were used to verify functionality when the test harness had linking issues, but are not part of the test suite and won't run via `npm test`.
-- **Suggestion:** Either move them to `test/manual/` or remove them if the hooks implementation is considered stable and the test harness issues are resolved.
-- **Impact:** Cleaner project root; reduces confusion about which test files are authoritative.
+~~### [L5] Manual test scripts in project root~~ **RESOLVED** — `test-hooks-with-logging.js`, `test-events-setup.js`, `test-hooks-manual.js` deleted during docs restructure.
 
 ---
 
@@ -136,4 +111,3 @@ The codebase is well-structured with clear separation of concerns and consistent
 **Longer term:**
 6. **M4/M5** — Cache introspected schemas in MysqlDB
 7. **M6** — Add DB unit tests
-8. **L1-L4** — Documentation cleanup pass

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -131,7 +131,7 @@ stonyx-orm/
 │       ├── db-schema.js             # Test DB schema
 │       ├── constants.js             # Test constants
 │       └── payload.js               # Sample raw + expected data
-├── .claude/                         # Claude AI assistant context docs
+├── .claude/                         # Agent entry point + code-style-rules
 ├── .github/workflows/
 │   ├── ci.yml                       # PR CI pipeline
 │   └── publish.yml                  # NPM publish workflow
@@ -339,5 +339,3 @@ See [improvements.md](improvements.md) for detailed findings. Key items:
 - `getOrSet` utility is duplicated across `has-many.js` and `belongs-to.js`
 - `getRelationshipInfo()` is duplicated across `orm-request.js`, `schema-introspector.js`, and `meta-request.js`
 - `getCollectionKeys()` and `getDirPath()` are duplicated between `db.js` and `migrate.js`
-- Package exports in `package.json` are missing `./commands` and `./hooks` entries (present in code but not in the outline docs)
-- The outline doc (`/.claude/personal/outline.md`) references files that don't exist (`src/include-parser.js`, `src/include-collector.js`, `stonyx-bootstrap.cjs`) and lists version as `0.1.0` (actual: `0.2.1-beta.1`)

--- a/docs/usage-patterns.md
+++ b/docs/usage-patterns.md
@@ -231,7 +231,7 @@ GET /scenes/e001-s001?include=slides.dialogue.character
 - `parseInclude()` - Splits comma-separated includes and parses nested paths
 - `traverseIncludePath()` - Recursively traverses relationship paths
 - `collectIncludedRecords()` - Orchestrates traversal and deduplication
-- All implemented in [src/orm-request.js](src/orm-request.js)
+- All implemented in [src/orm-request.js](../src/orm-request.js)
 
 ## 10. Views (Read-Only Computed Data)
 


### PR DESCRIPTION
## Summary
- Fix broken relative links in `docs/hooks.md` and `docs/usage-patterns.md` (source file paths need `../` prefix when referenced from `docs/`)
- Mark all Low Priority improvement items (L1-L5) as RESOLVED since the referenced files (`.claude/index.md`, `.claude/personal/outline.md`, root test scripts) were deleted during the docs restructure
- Remove stale known-issues in `docs/project-structure.md` that referenced deleted files
- Update `.claude/` directory description from vague "Claude AI assistant context docs" to accurate "Agent entry point + code-style-rules"

## Test plan
- [ ] Verify relative links in hooks.md and usage-patterns.md resolve correctly
- [ ] Confirm no remaining references to deleted `.claude/index.md` or `.claude/personal/outline.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)