### PR TITLE
fix: auto-create collection files on first save in directory mode

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,10 @@ importers:
         specifier: ^3.20.0
         version: 3.20.0(@types/node@25.5.0)
       qunit:
-        specifier: ^2.25.0
+        specifier: ^2.24.1
         version: 2.25.0
       sinon:
-        specifier: ^21.0.3
+        specifier: ^21.0.0
         version: 21.0.3
 
 packages:

--- a/src/db.js
+++ b/src/db.js
@@ -147,15 +147,25 @@ export default class DB {
       const collectionKeys = this.getCollectionKeys();
 
       // Write each collection to its own file in parallel
-      await Promise.all(collectionKeys.map(key =>
-        updateFile(path.join(dirPath, `${key}.json`), jsonData[key] || [], { json: true })
-      ));
+      // Use createFile for new files, updateFile for existing ones
+      await Promise.all(collectionKeys.map(async key => {
+        const filePath = path.join(dirPath, `${key}.json`);
+        const exists = await fileExists(filePath);
+        const data = jsonData[key] || [];
+
+        if (exists) await updateFile(filePath, data, { json: true });
+        else await createFile(filePath, data, { json: true });
+      }));
 
       // Write empty-array skeleton to db.json
       const skeleton = {};
       for (const key of collectionKeys) skeleton[key] = [];
 
-      await updateFile(`${config.rootPath}/${file}`, skeleton, { json: true });
+      const dbFilePath = `${config.rootPath}/${file}`;
+      const dbFileExists = await fileExists(dbFilePath);
+
+      if (dbFileExists) await updateFile(dbFilePath, skeleton, { json: true });
+      else await createFile(dbFilePath, skeleton, { json: true });
 
       log.db(`DB has been successfully saved to ${config.orm.db.directory}/ directory`);
       return;


### PR DESCRIPTION
## Summary
- In directory mode, `save()` called `updateFile()` for collection files that may not yet exist, causing ENOENT crashes on first save
- Added existence checks before each write: uses `createFile()` for new files and `updateFile()` for existing ones
- Applies to both individual collection files and the db.json skeleton file

Fixes abofs/stonyx-orm#30

## Test plan
- [x] All 477 existing tests pass
- [ ] Verify `Orm.db.save()` succeeds when collection files don't exist (first save)
- [ ] Verify files are created with correct JSON data on first save
- [ ] Verify subsequent saves still use atomic update pattern via `updateFile()`
- [ ] Verify both file and directory modes work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)