### PR TITLE
fix: suppress DB mode mismatch warnings in integration tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,10 @@ importers:
         specifier: ^3.20.0
         version: 3.20.0(@types/node@25.5.0)
       qunit:
-        specifier: ^2.25.0
+        specifier: ^2.24.1
         version: 2.25.0
       sinon:
-        specifier: ^21.0.3
+        specifier: ^21.0.0
         version: 21.0.3
 
 packages:

--- a/test/integration/db-directory-test.js
+++ b/test/integration/db-directory-test.js
@@ -6,6 +6,7 @@ import { serialized } from '../sample/payload.js';
 import { readFile, deleteFile, deleteDirectory, fileExists, createFile, createDirectory } from '@stonyx/utils/file';
 import { fileToDirectory, directoryToFile } from '../../src/migrate.js';
 import config from 'stonyx/config';
+import log from 'stonyx/log';
 import path from 'path';
 
 const { module, test } = QUnit;
@@ -149,14 +150,16 @@ module('[Integration] DB Directory Mode', function(hooks) {
 
   module('validateMode', function(hooks) {
     const testDbFile = './test/sample/db-validate-test.json';
-    let dirPath;
+    let dirPath, logErrorStub;
 
     hooks.beforeEach(function() {
       config.orm.db.file = testDbFile;
       dirPath = Orm.db.getDirPath();
+      logErrorStub = sinon.stub(log, 'error');
     });
 
     hooks.afterEach(async function() {
+      logErrorStub.restore();
       await deleteFile(path.resolve(`${config.rootPath}/${testDbFile}`), { ignoreAccessFailure: true });
       await deleteDirectory(dirPath);
     });


### PR DESCRIPTION
## Summary
- Stub `log.error` in the `validateMode` test module so intentional mode-mismatch test scenarios no longer print noisy warnings to stderr
- Production code is unchanged; errors are still logged in non-test contexts
- All 477 tests continue to pass with zero warnings

Fixes abofs/stonyx-orm#15

## Test plan
- [x] `pnpm test` passes with 477/477 tests, 0 failures
- [x] No "DB mode mismatch" warnings appear in test output
- [x] validateMode assertions still correctly verify `process.exit(1)` is called on mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)