### PR TITLE
docs: discourage __data and internal property access

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ A lightweight ORM for Stonyx projects, featuring model definitions, serializers,
 - **REST Server Integration**: Automatic route setup with customizable access control.
 - **Lifecycle Hooks**: Middleware-based before/after hooks for validation, authorization, side effects, and auditing.
 
+## Public API vs Internals
+
+Records use a proxy that exposes model attributes as direct properties. Always use direct property access for reading and writing field values:
+
+```js
+// Correct: read/write via the proxy
+const age = record.age;
+record.age = 5;
+
+// Correct: iterate fields using the record directly
+for (const key of Object.keys(record.serialize())) {
+  console.log(key, record[key]);
+}
+```
+
+All properties prefixed with `__` (`__data`, `__relationships`, `__model`, `__serializer`, `__serialized`) are **internal implementation details** and must not be accessed by consumer code. Bypassing the proxy by reading or writing `__data` directly skips type transforms and change tracking, which can lead to silent data corruption.
+
 ## Installation
 
 ```bash
@@ -417,7 +434,7 @@ Each hook receives a context object with comprehensive information:
 - It contains a deep copy of the record's state **before** the operation executes (captured before the `before` hook fires)
 - The deep copy is created via JSON serialization (`JSON.parse(JSON.stringify())`) to ensure complete isolation
 - For `delete` operations, `recordId` is provided in after hooks since the record may no longer exist in the store
-- `oldState` is captured from `record.__data` or the record itself, providing access to the raw data structure
+- `oldState` is captured as a deep copy of the record's data before the operation, providing access to the previous field values
 
 ### Usage Examples
 
@@ -520,8 +537,8 @@ afterHook('update', 'animal', async (context) => {
 
   // Track multiple field changes
   const changedFields = [];
-  for (const key in context.record.__data) {
-    if (context.oldState[key] !== context.record.__data[key]) {
+  for (const key of Object.keys(context.oldState)) {
+    if (context.oldState[key] !== context.record[key]) {
       changedFields.push(key);
     }
   }
@@ -560,9 +577,9 @@ afterHook('update', 'animal', async (context) => {
   // Compare oldState with current record to capture exact changes
   const changes = {};
   if (context.oldState) {
-    for (const [key, newValue] of Object.entries(context.record.__data || context.record)) {
-      if (context.oldState[key] !== newValue) {
-        changes[key] = { from: context.oldState[key], to: newValue };
+    for (const key of Object.keys(context.oldState)) {
+      if (context.oldState[key] !== context.record[key]) {
+        changes[key] = { from: context.oldState[key], to: context.record[key] };
       }
     }
   }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -124,7 +124,7 @@ _withHooks(operation, handler) {
     if (operation === 'update' || operation === 'delete') {
       const existingRecord = store.get(this.model, getId(request.params));
       if (existingRecord) {
-        context.oldState = JSON.parse(JSON.stringify(existingRecord.__data || existingRecord));
+        context.oldState = JSON.parse(JSON.stringify(existingRecord));
       }
     }
 
@@ -198,9 +198,9 @@ afterHook('update', 'animal', (context) => {
 afterHook('update', 'animal', async (context) => {
   const changes = {};
   if (context.oldState) {
-    for (const [key, newValue] of Object.entries(context.record.__data)) {
-      if (context.oldState[key] !== newValue) {
-        changes[key] = { from: context.oldState[key], to: newValue };
+    for (const key of Object.keys(context.oldState)) {
+      if (context.oldState[key] !== context.record[key]) {
+        changes[key] = { from: context.oldState[key], to: context.record[key] };
       }
     }
   }

--- a/docs/usage-patterns.md
+++ b/docs/usage-patterns.md
@@ -271,7 +271,7 @@ export default class OwnerStatsView extends View {
   static source = 'owner';
   static resolve = {
     gender: 'gender',              // String path from source data
-    score: (owner) => owner.__data.age * 10,  // Function
+    score: (owner) => owner.age * 10,  // Function
   };
 
   gender = attr('string');  // Must also define as attr()

--- a/docs/views.md
+++ b/docs/views.md
@@ -75,7 +75,7 @@ export default class OwnerStatsView extends View {
   static resolve = {
     gender: 'gender',           // String path: maps from source record data
     score: (owner) => {         // Function: custom computation
-      return owner.__data.age * 10;
+      return owner.age * 10;
     },
     nestedVal: 'details.nested', // Nested string paths supported
   };
@@ -138,7 +138,7 @@ export default class LeagueStatsView extends View {
   static resolve = {
     totalGoals: (groupRecords) => {
       return groupRecords.reduce((sum, r) => {
-        const fs = r.__data.finalScore;
+        const fs = r.finalScore;
         return fs ? sum + fs[0] + fs[1] : sum;
       }, 0);
     },
@@ -267,7 +267,7 @@ QUnit.test('view returns computed data', async function(assert) {
   const results = await store.findAll('owner-stats');
   const stat = results.find(r => r.id === 1);
 
-  assert.strictEqual(stat.__data.animalCount, 1);
+  assert.strictEqual(stat.animalCount, 1);
 });
 ```
 

--- a/src/record.js
+++ b/src/record.js
@@ -3,12 +3,17 @@ import { getComputedProperties } from "./serializer.js";
 import { camelCaseToKebabCase } from '@stonyx/utils/string';
 import { getPluralName } from './plural-registry.js';
 export default class Record {
+  /** @private */
   __data = {};
+  /** @private */
   __relationships = {};
+  /** @private */
   __serialized = false;
 
   constructor(model, serializer) {
+    /** @private */
     this.__model = model;
+    /** @private */
     this.__serializer = serializer;
 
   }


### PR DESCRIPTION
## Summary
- Replace all `__data` usage in doc/README examples with direct proxy access (`record.fieldName`) and `Object.keys` iteration patterns
- Add a "Public API vs Internals" section to the README explaining that `__`-prefixed properties are internal and bypassing the proxy skips type transforms and change tracking
- Add `@private` JSDoc annotations to `__data`, `__relationships`, `__model`, `__serializer`, `__serialized` in `src/record.js`

## Test plan
- [x] All 504 existing tests pass (`pnpm test`)
- [ ] Verify doc examples are accurate by visual review

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)