### PR TITLE
fix: guard against undefined model stores in relationship resolution

### DIFF
--- a/src/belongs-to.js
+++ b/src/belongs-to.js
@@ -21,9 +21,13 @@ export default function belongsTo(modelName) {
     const modelStore = store.get(modelName);
 
     // Try to get existing record
-    const output = typeof rawData === 'object'
-      ? createRecord(modelName, rawData, options)
-      : modelStore.get(rawData);
+    let output;
+
+    if (typeof rawData === 'object') {
+      output = createRecord(modelName, rawData, options);
+    } else if (modelStore) {
+      output = modelStore.get(rawData);
+    }
 
     // If not found and is a string ID, register as pending
     if (!output && typeof rawData !== 'object') {

--- a/src/has-many.js
+++ b/src/has-many.js
@@ -27,6 +27,10 @@ export default function hasMany(modelName) {
       let record;
 
       if (typeof elementData !== 'object') {
+        if (!modelStore) {
+          return queuePendingRelationship(pendingRelationshipQueue, pendingRelationships, modelName, elementData);
+        }
+
         record = modelStore.get(elementData);
 
         if (!record) {

--- a/src/manage-record.js
+++ b/src/manage-record.js
@@ -23,6 +23,8 @@ export function createRecord(modelName, rawData={}, userOptions={}) {
   const globalRelationships = relationships.get('global');
   const pendingRelationships = relationships.get('pending');
 
+  if (!modelStore) throw new Error(`Model store for '${modelName}' is not registered. Ensure the model is defined before creating records.`);
+
   assignRecordId(modelName, rawData);
   if (modelStore.has(rawData.id)) return modelStore.get(rawData.id);
 

--- a/test/unit/unregistered-model-test.js
+++ b/test/unit/unregistered-model-test.js
@@ -1,0 +1,71 @@
+import QUnit from 'qunit';
+import { createRecord, store, relationships } from '@stonyx/orm';
+
+const { module, test } = QUnit;
+
+module('[Unit] Unregistered model guards', function(hooks) {
+  hooks.afterEach(function() {
+    // Restore any deleted store entries
+    for (const model of ['trait', 'category', 'owner', 'animal']) {
+      if (!store.get(model)) store.set(model, new Map());
+      else store.get(model).clear();
+    }
+
+    relationships.get('hasMany')?.clear();
+    relationships.get('belongsTo')?.clear();
+    relationships.get('pending')?.clear();
+    relationships.get('pendingBelongsTo')?.clear();
+  });
+
+  test('createRecord throws a descriptive error for an unregistered model', function(assert) {
+    assert.throws(
+      () => createRecord('nonexistent-model', { id: 1 }),
+      /Model store for 'nonexistent-model' is not registered/,
+      'throws a clear error instead of TypeError'
+    );
+  });
+
+  test('belongsTo with unregistered target model queues as pending instead of crashing', function(assert) {
+    // Remove the category store to simulate an unregistered model
+    const categoryStore = store.get('category');
+    store.data.delete('category');
+
+    try {
+      // trait model has belongsTo('category') — with category store deleted, this should not throw
+      const trait = createRecord('trait', { id: 1, type: 'color', value: 'black', category: 'appearance' });
+
+      assert.equal(trait.category, null, 'belongsTo returns null when target model is unregistered');
+
+      const pendingBelongsTo = relationships.get('pendingBelongsTo');
+      const pendingForCategory = pendingBelongsTo.get('category');
+
+      assert.ok(pendingForCategory, 'pending belongsTo queue created for unregistered model');
+      assert.ok(pendingForCategory.get('appearance'), 'pending entry registered for the target ID');
+    } finally {
+      // Restore
+      store.set('category', categoryStore);
+    }
+  });
+
+  test('hasMany with unregistered target model queues as pending instead of crashing', function(assert) {
+    // Remove the phone-number store to simulate an unregistered model
+    const phoneStore = store.get('phone-number');
+    store.data.delete('phone-number');
+
+    try {
+      // owner model has hasMany('phone-number') — with phone-number store deleted,
+      // string ID references should queue as pending, not throw a TypeError
+      const owner = createRecord('owner', { name: 'TestOwner', phoneNumbers: ['pn-1', 'pn-2'] });
+
+      assert.deepEqual(owner.phoneNumbers, [], 'hasMany returns empty array when target model is unregistered');
+
+      const pendingRelationships = relationships.get('pending');
+      const pendingForPhone = pendingRelationships.get('phone-number');
+
+      assert.ok(pendingForPhone, 'pending queue created for unregistered model');
+    } finally {
+      // Restore
+      store.set('phone-number', phoneStore);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add null guard in `has-many.js` so string ID references to unregistered models queue as pending instead of throwing `TypeError: Cannot read properties of undefined (reading 'get')`
- Add null guard in `belongs-to.js` so string ID references to unregistered models fall through to the existing pending-registration path instead of crashing
- Add explicit error in `manage-record.js` when `createRecord` is called for a model with no store entry, replacing the cryptic `TypeError: Cannot read properties of undefined (reading 'has')` with a descriptive message

Closes abofs/stonyx#30

## Test plan
- [x] New unit test: `createRecord` with unregistered model throws descriptive error (not TypeError)
- [x] New unit test: `belongsTo` with unregistered target model queues as pending, returns null
- [x] New unit test: `hasMany` with unregistered target model queues as pending, returns empty array
- [x] Full test suite passes (507/507)

🤖 Generated with [Claude Code](https://claude.com/claude-code)