### PR TITLE
refactor: generic SQL adapter naming for multi-dialect support

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -111,9 +111,9 @@ export default class Orm {
 
     if (config.orm.mysql) {
       const { default: MysqlDB } = await import('./mysql/mysql-db.js');
-      this.mysqlDb = new MysqlDB();
-      this.db = this.mysqlDb;
-      promises.push(this.mysqlDb.init());
+      this.sqlDb = new MysqlDB();
+      this.db = this.sqlDb;
+      promises.push(this.sqlDb.init());
     } else if (this.options.dbType !== 'none') {
       const db = new DB();
       this.db = db;
@@ -131,9 +131,9 @@ export default class Orm {
       return modelClass?.memory === true;
     };
 
-    // Wire up MySQL reference for on-demand queries from store.find()/findAll()
-    if (this.mysqlDb) {
-      Orm.store._mysqlDb = this.mysqlDb;
+    // Wire up SQL adapter reference for on-demand queries from store.find()/findAll()
+    if (this.sqlDb) {
+      Orm.store._sqlDb = this.sqlDb;
     }
 
     Orm.ready = await Promise.all(promises);
@@ -141,11 +141,11 @@ export default class Orm {
   }
 
   async startup() {
-    if (this.mysqlDb) await this.mysqlDb.startup();
+    if (this.sqlDb) await this.sqlDb.startup();
   }
 
   async shutdown() {
-    if (this.mysqlDb) await this.mysqlDb.shutdown();
+    if (this.sqlDb) await this.sqlDb.shutdown();
   }
 
   static get db() {

--- a/src/manage-record.js
+++ b/src/manage-record.js
@@ -110,10 +110,10 @@ export function updateRecord(record, rawData, userOptions={}) {
 function assignRecordId(modelName, rawData) {
   if (rawData.id) return;
 
-  // In MySQL mode with numeric IDs, defer to MySQL auto-increment
-  if (Orm.instance?.mysqlDb && !isStringIdModel(modelName)) {
+  // In SQL mode with numeric IDs, defer to database auto-increment
+  if (Orm.instance?.sqlDb && !isStringIdModel(modelName)) {
     rawData.id = `__pending_${Date.now()}_${Math.random()}`;
-    rawData.__pendingMysqlId = true;
+    rawData.__pendingSqlId = true;
     return;
   }
 

--- a/src/mysql/mysql-db.js
+++ b/src/mysql/mysql-db.js
@@ -352,7 +352,7 @@ export default class MysqlDB {
     const insertData = this._recordToRow(record, schema);
 
     // For auto-increment models, remove the pending ID
-    const isPendingId = record.__data.__pendingMysqlId;
+    const isPendingId = record.__data.__pendingSqlId;
 
     if (isPendingId) {
       delete insertData.id;
@@ -380,7 +380,7 @@ export default class MysqlDB {
         response.data.id = realId;
       }
 
-      delete record.__data.__pendingMysqlId;
+      delete record.__data.__pendingSqlId;
     }
   }
 

--- a/src/orm-request.js
+++ b/src/orm-request.js
@@ -385,9 +385,9 @@ export default class OrmRequest extends Request {
       // Execute main handler
       const response = await handler(request, state);
 
-      // Persist to MySQL for write operations
-      if (Orm.instance.mysqlDb && WRITE_OPERATIONS.has(operation)) {
-        await Orm.instance.mysqlDb.persist(operation, this.model, context, response);
+      // Persist to SQL database for write operations
+      if (Orm.instance.sqlDb && WRITE_OPERATIONS.has(operation)) {
+        await Orm.instance.sqlDb.persist(operation, this.model, context, response);
       }
 
       // Add response and relevant records to context

--- a/src/store.js
+++ b/src/store.js
@@ -22,15 +22,15 @@ export default class Store {
   }
 
   /**
-   * Async authoritative read. Always queries MySQL for memory: false models.
+   * Async authoritative read. Always queries the SQL database for memory: false models.
    * For memory: true models, returns from store (already loaded on boot).
    * @param {string} modelName - The model name
    * @param {string|number} id - The record ID
    * @returns {Promise<Record|undefined>}
    */
   async find(modelName, id) {
-    // For views in non-MySQL mode, use view resolver
-    if (Orm.instance?.isView?.(modelName) && !this._mysqlDb) {
+    // For views in non-SQL mode, use view resolver
+    if (Orm.instance?.isView?.(modelName) && !this._sqlDb) {
       const resolver = new ViewResolver(modelName);
       return resolver.resolveOne(id);
     }
@@ -40,12 +40,12 @@ export default class Store {
       return this.get(modelName, id);
     }
 
-    // For memory: false models, always query MySQL
-    if (this._mysqlDb) {
-      return this._mysqlDb.findRecord(modelName, id);
+    // For memory: false models, always query the SQL database
+    if (this._sqlDb) {
+      return this._sqlDb.findRecord(modelName, id);
     }
 
-    // Fallback to store (JSON mode or no MySQL)
+    // Fallback to store (JSON mode or no SQL adapter)
     return this.get(modelName, id);
   }
 
@@ -57,8 +57,8 @@ export default class Store {
    * @returns {Promise<Record[]>}
    */
   async findAll(modelName, conditions) {
-    // For views in non-MySQL mode, use view resolver
-    if (Orm.instance?.isView?.(modelName) && !this._mysqlDb) {
+    // For views in non-SQL mode, use view resolver
+    if (Orm.instance?.isView?.(modelName) && !this._sqlDb) {
       const resolver = new ViewResolver(modelName);
       const records = await resolver.resolveAll();
 
@@ -75,9 +75,9 @@ export default class Store {
       return modelStore ? Array.from(modelStore.values()) : [];
     }
 
-    // For memory: false models (or filtered queries), always query MySQL
-    if (this._mysqlDb) {
-      return this._mysqlDb.findAll(modelName, conditions);
+    // For memory: false models (or filtered queries), always query the SQL database
+    if (this._sqlDb) {
+      return this._sqlDb.findAll(modelName, conditions);
     }
 
     // Fallback to store (JSON mode) — apply conditions in-memory if provided
@@ -101,8 +101,8 @@ export default class Store {
    * @returns {Promise<Record[]>}
    */
   async query(modelName, conditions = {}) {
-    if (this._mysqlDb) {
-      return this._mysqlDb.findAll(modelName, conditions);
+    if (this._sqlDb) {
+      return this._sqlDb.findAll(modelName, conditions);
     }
 
     // Fallback: filter in-memory store
@@ -125,10 +125,10 @@ export default class Store {
   _memoryResolver = null;
 
   /**
-   * Set by Orm during init — reference to the MysqlDB instance for on-demand queries.
-   * @type {MysqlDB|null}
+   * Set by Orm during init — reference to the SQL adapter instance for on-demand queries.
+   * @type {object|null}
    */
-  _mysqlDb = null;
+  _sqlDb = null;
 
   /**
    * Check if a model is configured for in-memory storage.

--- a/test/unit/orm-lifecycle-test.js
+++ b/test/unit/orm-lifecycle-test.js
@@ -17,18 +17,18 @@ module('[Unit] Orm Lifecycle', function(hooks) {
   });
 
   module('startup', function() {
-    test('calls mysqlDb.startup() when mysqlDb exists', async function(assert) {
+    test('calls sqlDb.startup() when sqlDb exists', async function(assert) {
       const orm = Object.create(Orm.prototype);
-      orm.mysqlDb = { startup: sinon.stub().resolves() };
+      orm.sqlDb = { startup: sinon.stub().resolves() };
 
       await orm.startup();
 
-      assert.ok(orm.mysqlDb.startup.calledOnce, 'mysqlDb.startup was called');
+      assert.ok(orm.sqlDb.startup.calledOnce, 'sqlDb.startup was called');
     });
 
-    test('is a no-op when mysqlDb is not set', async function(assert) {
+    test('is a no-op when sqlDb is not set', async function(assert) {
       const orm = Object.create(Orm.prototype);
-      orm.mysqlDb = undefined;
+      orm.sqlDb = undefined;
 
       await orm.startup();
       assert.ok(true, 'did not throw');
@@ -36,18 +36,18 @@ module('[Unit] Orm Lifecycle', function(hooks) {
   });
 
   module('shutdown', function() {
-    test('calls mysqlDb.shutdown() when mysqlDb exists', async function(assert) {
+    test('calls sqlDb.shutdown() when sqlDb exists', async function(assert) {
       const orm = Object.create(Orm.prototype);
-      orm.mysqlDb = { shutdown: sinon.stub().resolves() };
+      orm.sqlDb = { shutdown: sinon.stub().resolves() };
 
       await orm.shutdown();
 
-      assert.ok(orm.mysqlDb.shutdown.calledOnce, 'mysqlDb.shutdown was called');
+      assert.ok(orm.sqlDb.shutdown.calledOnce, 'sqlDb.shutdown was called');
     });
 
-    test('is a no-op when mysqlDb is not set', async function(assert) {
+    test('is a no-op when sqlDb is not set', async function(assert) {
       const orm = Object.create(Orm.prototype);
-      orm.mysqlDb = undefined;
+      orm.sqlDb = undefined;
 
       await orm.shutdown();
       assert.ok(true, 'did not throw');

--- a/test/unit/store-find-test.js
+++ b/test/unit/store-find-test.js
@@ -32,43 +32,43 @@ module('[Unit] Store.find', function(hooks) {
     assert.strictEqual(record.name, 'Alice', 'returns record from memory');
   });
 
-  test('find queries MySQL for memory:false models', async function(assert) {
+  test('find queries SQL for memory:false models', async function(assert) {
     const store = createStore();
     store._memoryResolver = (name) => name !== 'alert';
 
     const mockRecord = { id: 42, message: 'test' };
-    store._mysqlDb = {
+    store._sqlDb = {
       findRecord: sinon.stub().resolves(mockRecord)
     };
 
     const record = await store.find('alert', 42);
 
-    assert.ok(store._mysqlDb.findRecord.calledOnce, 'findRecord called on mysqlDb');
-    assert.deepEqual(store._mysqlDb.findRecord.firstCall.args, ['alert', 42], 'called with correct args');
-    assert.strictEqual(record, mockRecord, 'returns MySQL result');
+    assert.ok(store._sqlDb.findRecord.calledOnce, 'findRecord called on sqlDb');
+    assert.deepEqual(store._sqlDb.findRecord.firstCall.args, ['alert', 42], 'called with correct args');
+    assert.strictEqual(record, mockRecord, 'returns SQL result');
   });
 
-  test('find falls back to memory when no MySQL configured', async function(assert) {
+  test('find falls back to memory when no SQL configured', async function(assert) {
     const store = createStore();
     store._memoryResolver = () => false;
-    store._mysqlDb = null;
+    store._sqlDb = null;
 
     const record = await store.find('user', 1);
     assert.strictEqual(record.name, 'Alice', 'falls back to in-memory store');
   });
 
-  test('find defaults to memory:false when no resolver set (queries MySQL)', async function(assert) {
+  test('find defaults to memory:false when no resolver set (queries SQL)', async function(assert) {
     const store = createStore();
     store._memoryResolver = null;
 
     const mockRecord = { id: 1, name: 'Alice' };
-    store._mysqlDb = {
+    store._sqlDb = {
       findRecord: sinon.stub().resolves(mockRecord)
     };
 
     const record = await store.find('user', 1);
-    assert.ok(store._mysqlDb.findRecord.calledOnce, 'queries MySQL when no resolver');
-    assert.strictEqual(record, mockRecord, 'returns MySQL result');
+    assert.ok(store._sqlDb.findRecord.calledOnce, 'queries SQL when no resolver');
+    assert.strictEqual(record, mockRecord, 'returns SQL result');
   });
 });
 
@@ -88,35 +88,35 @@ module('[Unit] Store.findAll', function(hooks) {
     assert.strictEqual(records[1].name, 'Bob', 'second record correct');
   });
 
-  test('findAll queries MySQL for memory:false models', async function(assert) {
+  test('findAll queries SQL for memory:false models', async function(assert) {
     const store = createStore();
     store._memoryResolver = (name) => name !== 'alert';
 
     const mockRecords = [{ id: 1 }, { id: 2 }];
-    store._mysqlDb = {
+    store._sqlDb = {
       findAll: sinon.stub().resolves(mockRecords)
     };
 
     const records = await store.findAll('alert');
 
-    assert.ok(store._mysqlDb.findAll.calledOnce, 'findAll called on mysqlDb');
-    assert.deepEqual(store._mysqlDb.findAll.firstCall.args, ['alert', undefined], 'called with model name');
-    assert.strictEqual(records, mockRecords, 'returns MySQL results');
+    assert.ok(store._sqlDb.findAll.calledOnce, 'findAll called on sqlDb');
+    assert.deepEqual(store._sqlDb.findAll.firstCall.args, ['alert', undefined], 'called with model name');
+    assert.strictEqual(records, mockRecords, 'returns SQL results');
   });
 
-  test('findAll with conditions queries MySQL even for memory:true models', async function(assert) {
+  test('findAll with conditions queries SQL even for memory:true models', async function(assert) {
     const store = createStore();
     store._memoryResolver = () => true;
 
     const mockRecords = [{ id: 1, status: 'active' }];
-    store._mysqlDb = {
+    store._sqlDb = {
       findAll: sinon.stub().resolves(mockRecords)
     };
 
     const records = await store.findAll('user', { status: 'active' });
 
-    assert.ok(store._mysqlDb.findAll.calledOnce, 'queries MySQL when conditions provided');
-    assert.strictEqual(records, mockRecords, 'returns filtered MySQL results');
+    assert.ok(store._sqlDb.findAll.calledOnce, 'queries SQL when conditions provided');
+    assert.strictEqual(records, mockRecords, 'returns filtered SQL results');
   });
 
   test('findAll returns empty array for empty model store', async function(assert) {
@@ -142,25 +142,25 @@ module('[Unit] Store.query', function(hooks) {
     sinon.restore();
   });
 
-  test('query always hits MySQL when available', async function(assert) {
+  test('query always hits SQL when available', async function(assert) {
     const store = createStore();
     store._memoryResolver = () => true;
 
     const mockRecords = [{ id: 1 }];
-    store._mysqlDb = {
+    store._sqlDb = {
       findAll: sinon.stub().resolves(mockRecords)
     };
 
     const records = await store.query('user', { name: 'Alice' });
 
-    assert.ok(store._mysqlDb.findAll.calledOnce, 'always hits MySQL');
-    assert.deepEqual(store._mysqlDb.findAll.firstCall.args, ['user', { name: 'Alice' }], 'passes conditions');
-    assert.strictEqual(records, mockRecords, 'returns MySQL results');
+    assert.ok(store._sqlDb.findAll.calledOnce, 'always hits SQL');
+    assert.deepEqual(store._sqlDb.findAll.firstCall.args, ['user', { name: 'Alice' }], 'passes conditions');
+    assert.strictEqual(records, mockRecords, 'returns SQL results');
   });
 
-  test('query falls back to in-memory filtering when no MySQL', async function(assert) {
+  test('query falls back to in-memory filtering when no SQL', async function(assert) {
     const store = createStore();
-    store._mysqlDb = null;
+    store._sqlDb = null;
 
     const records = await store.query('user', { name: 'Alice' });
 
@@ -168,9 +168,9 @@ module('[Unit] Store.query', function(hooks) {
     assert.strictEqual(records[0].name, 'Alice', 'returns matching record');
   });
 
-  test('query returns all records when no conditions and no MySQL', async function(assert) {
+  test('query returns all records when no conditions and no SQL', async function(assert) {
     const store = createStore();
-    store._mysqlDb = null;
+    store._sqlDb = null;
 
     const records = await store.query('user');
 
@@ -179,7 +179,7 @@ module('[Unit] Store.query', function(hooks) {
 
   test('query returns empty array for no matches in memory fallback', async function(assert) {
     const store = createStore();
-    store._mysqlDb = null;
+    store._sqlDb = null;
 
     const records = await store.query('user', { name: 'Charlie' });
 

--- a/test/unit/view-rest-test.js
+++ b/test/unit/view-rest-test.js
@@ -14,7 +14,7 @@ module('[Unit] View REST endpoints', function(hooks) {
     Orm.instance = {
       getRecordClasses: sinon.stub().returns({ modelClass: null, serializerClass: null }),
       isView: sinon.stub(),
-      mysqlDb: null,
+      sqlDb: null,
       transforms: {
         number: (v) => parseInt(v),
         passthrough: (v) => v,


### PR DESCRIPTION
## Summary

- Renames MySQL-specific adapter properties to generic SQL names, enabling a PostgreSQL/pgvector adapter to plug in alongside MySQL
- `this.mysqlDb` → `this.sqlDb`, `this._mysqlDb` → `this._sqlDb`, `__pendingMysqlId` → `__pendingSqlId`
- Updates all JSDoc comments and test assertions to use generic terminology

## Context

Wave 1 of Sprint 10 (#45 — pgvector driver). This refactor is the foundation — Wave 2 will add `src/postgres/` with the pgvector driver, using the same `sqlDb` / `_sqlDb` adapter interface.

Internal MySQL adapter code (`src/mysql/`) retains MySQL-specific naming. Only the public-facing adapter properties that the store, main init, and request handler reference are renamed.

## Test plan

- [x] All 507 existing tests pass (0 failures, 0 skipped)
- [x] grep confirms zero remaining `mysqlDb`/`_mysqlDb`/`__pendingMysqlId` references in `src/`
- [x] MySQL integration tests still work (adapter wiring unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)