### PR TITLE
feat: add PostgreSQL/pgvector driver with HNSW vector search

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -19,6 +19,13 @@ const {
   MYSQL_DATABASE,
   MYSQL_CONNECTION_LIMIT,
   MYSQL_MIGRATIONS_DIR,
+  PG_HOST,
+  PG_PORT,
+  PG_USER,
+  PG_PASSWORD,
+  PG_DATABASE,
+  PG_CONNECTION_LIMIT,
+  PG_MIGRATIONS_DIR,
 } = process.env;
 
 export default {
@@ -48,6 +55,16 @@ export default {
     database: MYSQL_DATABASE ?? 'stonyx',
     connectionLimit: parseInt(MYSQL_CONNECTION_LIMIT ?? '10'),
     migrationsDir: MYSQL_MIGRATIONS_DIR ?? 'migrations',
+    migrationsTable: '__migrations',
+  } : undefined,
+  postgres: PG_HOST ? {
+    host: PG_HOST ?? 'localhost',
+    port: parseInt(PG_PORT ?? '5432'),
+    user: PG_USER ?? 'postgres',
+    password: PG_PASSWORD ?? '',
+    database: PG_DATABASE ?? 'stonyx',
+    connectionLimit: parseInt(PG_CONNECTION_LIMIT ?? '10'),
+    migrationsDir: PG_MIGRATIONS_DIR ?? 'migrations',
     migrationsTable: '__migrations',
   } : undefined,
   restServer: {

--- a/package.json
+++ b/package.json
@@ -52,10 +52,14 @@
   },
   "peerDependencies": {
     "@stonyx/rest-server": ">=0.2.1-beta.14",
-    "mysql2": "^3.0.0"
+    "mysql2": "^3.0.0",
+    "pg": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "mysql2": {
+      "optional": true
+    },
+    "pg": {
       "optional": true
     },
     "@stonyx/rest-server": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@stonyx/rest-server": "0.2.1-beta.30",
     "@stonyx/utils": "0.2.3-beta.7",
     "mysql2": "^3.20.0",
+    "pg": "^8.20.0",
     "qunit": "^2.24.1",
     "sinon": "^21.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       mysql2:
         specifier: ^3.20.0
         version: 3.20.0(@types/node@25.5.0)
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
       qunit:
         specifier: ^2.24.1
         version: 2.25.0
@@ -318,6 +321,56 @@ packages:
   path@0.12.7:
     resolution: {integrity: sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -383,6 +436,10 @@ packages:
   sinon@21.0.3:
     resolution: {integrity: sha512-0x8TQFr8EjADhSME01u1ZK31yv2+bd6Z5NrBCHVM+n4qL1wFqbxftmeyi3bwlr49FbbzRfrqSFOpyHCOh/YmYA==}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   sql-escaper@1.3.3:
     resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
@@ -438,6 +495,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
 snapshots:
 
@@ -732,6 +793,51 @@ snapshots:
       process: 0.11.10
       util: 0.10.4
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
   process@0.11.10: {}
 
   proxy-addr@2.0.7:
@@ -835,6 +941,8 @@ snapshots:
       diff: 8.0.4
       supports-color: 7.2.0
 
+  split2@4.2.0: {}
+
   sql-escaper@1.3.3: {}
 
   statuses@2.0.2: {}
@@ -880,3 +988,5 @@ snapshots:
   vary@1.1.2: {}
 
   wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}

--- a/src/main.js
+++ b/src/main.js
@@ -109,7 +109,12 @@ export default class Orm {
 
     setup(eventNames);
 
-    if (config.orm.mysql) {
+    if (config.orm.postgres) {
+      const { default: PostgresDB } = await import('./postgres/postgres-db.js');
+      this.sqlDb = new PostgresDB();
+      this.db = this.sqlDb;
+      promises.push(this.sqlDb.init());
+    } else if (config.orm.mysql) {
       const { default: MysqlDB } = await import('./mysql/mysql-db.js');
       this.sqlDb = new MysqlDB();
       this.db = this.sqlDb;

--- a/src/postgres/connection.js
+++ b/src/postgres/connection.js
@@ -1,0 +1,30 @@
+let pool = null;
+
+export async function getPool(pgConfig) {
+  if (pool) return pool;
+
+  const { default: pg } = await import('pg');
+
+  pool = new pg.Pool({
+    host: pgConfig.host,
+    port: pgConfig.port,
+    user: pgConfig.user,
+    password: pgConfig.password,
+    database: pgConfig.database,
+    max: pgConfig.connectionLimit,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+
+  // Enable pgvector extension
+  await pool.query('CREATE EXTENSION IF NOT EXISTS vector');
+
+  return pool;
+}
+
+export async function closePool() {
+  if (!pool) return;
+
+  await pool.end();
+  pool = null;
+}

--- a/src/postgres/migration-generator.js
+++ b/src/postgres/migration-generator.js
@@ -1,0 +1,302 @@
+import { introspectModels, introspectViews, buildTableDDL, buildViewDDL, buildVectorIndexDDL, schemasToSnapshot, viewSchemasToSnapshot, getTopologicalOrder } from './schema-introspector.js';
+import { readFile, createFile, createDirectory, fileExists } from '@stonyx/utils/file';
+import path from 'path';
+import config from 'stonyx/config';
+import log from 'stonyx/log';
+
+export async function generateMigration(description = 'migration') {
+  const { migrationsDir } = config.orm.postgres;
+  const rootPath = config.rootPath;
+  const migrationsPath = path.resolve(rootPath, migrationsDir);
+
+  await createDirectory(migrationsPath);
+
+  const schemas = introspectModels();
+  const currentSnapshot = schemasToSnapshot(schemas);
+  const previousSnapshot = await loadLatestSnapshot(migrationsPath);
+  const diff = diffSnapshots(previousSnapshot, currentSnapshot);
+
+  // Don't return early — check view changes too before deciding
+  if (!diff.hasChanges) {
+    const viewSchemasPrelim = introspectViews();
+    const currentViewSnapshotPrelim = viewSchemasToSnapshot(viewSchemasPrelim);
+    const previousViewSnapshotPrelim = extractViewsFromSnapshot(previousSnapshot);
+    const viewDiffPrelim = diffViewSnapshots(previousViewSnapshotPrelim, currentViewSnapshotPrelim);
+
+    if (!viewDiffPrelim.hasChanges) {
+      log.db('No schema changes detected.');
+      return null;
+    }
+  }
+
+  const upStatements = [];
+  const downStatements = [];
+
+  // pgvector extension (include in initial migration)
+  if (Object.keys(previousSnapshot).length === 0) {
+    upStatements.push('CREATE EXTENSION IF NOT EXISTS vector;');
+  }
+
+  // New tables — in topological order (parents before children)
+  const allOrder = getTopologicalOrder(schemas);
+  const addedOrdered = allOrder.filter(name => diff.addedModels.includes(name));
+
+  for (const name of addedOrdered) {
+    upStatements.push(buildTableDDL(name, schemas[name], schemas) + ';');
+
+    // HNSW indexes for vector columns
+    const indexStatements = buildVectorIndexDDL(name, schemas[name]);
+    for (const stmt of indexStatements) {
+      upStatements.push(stmt + ';');
+    }
+
+    downStatements.unshift(`DROP TABLE IF EXISTS "${schemas[name].table}" CASCADE;`);
+  }
+
+  // Removed tables (warn only, commented out)
+  for (const name of diff.removedModels) {
+    upStatements.push(`-- WARNING: Model '${name}' was removed. Uncomment to drop table:`);
+    upStatements.push(`-- DROP TABLE IF EXISTS "${previousSnapshot[name].table}" CASCADE;`);
+    downStatements.push(`-- Recreate table for removed model '${name}' manually if needed`);
+  }
+
+  // Added columns
+  for (const { model, column, type } of diff.addedColumns) {
+    const table = currentSnapshot[model].table;
+    upStatements.push(`ALTER TABLE "${table}" ADD COLUMN "${column}" ${type};`);
+    downStatements.push(`ALTER TABLE "${table}" DROP COLUMN "${column}";`);
+
+    // Add HNSW index if it's a vector column
+    if (type.startsWith('vector(')) {
+      upStatements.push(`CREATE INDEX IF NOT EXISTS "idx_${table}_${column}_hnsw" ON "${table}" USING hnsw ("${column}" vector_cosine_ops) WITH (m = 16, ef_construction = 200);`);
+    }
+  }
+
+  // Removed columns
+  for (const { model, column, type } of diff.removedColumns) {
+    const table = previousSnapshot[model].table;
+    upStatements.push(`ALTER TABLE "${table}" DROP COLUMN "${column}";`);
+    downStatements.push(`ALTER TABLE "${table}" ADD COLUMN "${column}" ${type};`);
+  }
+
+  // Changed column types
+  for (const { model, column, from, to } of diff.changedColumns) {
+    const table = currentSnapshot[model].table;
+    upStatements.push(`ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE ${to};`);
+    downStatements.push(`ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE ${from};`);
+  }
+
+  // Added foreign keys
+  for (const { model, column, references } of diff.addedForeignKeys) {
+    const table = currentSnapshot[model].table;
+    const refModel = Object.entries(currentSnapshot).find(([, s]) => s.table === references.references);
+    const fkType = refModel && refModel[1].idType === 'string' ? 'VARCHAR(255)' : 'INTEGER';
+    const constraintName = `fk_${table}_${column}`;
+    upStatements.push(`ALTER TABLE "${table}" ADD COLUMN "${column}" ${fkType};`);
+    upStatements.push(`ALTER TABLE "${table}" ADD CONSTRAINT "${constraintName}" FOREIGN KEY ("${column}") REFERENCES "${references.references}"("${references.column}") ON DELETE SET NULL;`);
+    downStatements.push(`ALTER TABLE "${table}" DROP CONSTRAINT "${constraintName}";`);
+    downStatements.push(`ALTER TABLE "${table}" DROP COLUMN "${column}";`);
+  }
+
+  // Removed foreign keys
+  for (const { model, column, references } of diff.removedForeignKeys) {
+    const table = previousSnapshot[model].table;
+    const refModel = Object.entries(previousSnapshot).find(([, s]) => s.table === references.references);
+    const fkType = refModel && refModel[1].idType === 'string' ? 'VARCHAR(255)' : 'INTEGER';
+    const constraintName = `fk_${table}_${column}`;
+    upStatements.push(`ALTER TABLE "${table}" DROP CONSTRAINT "${constraintName}";`);
+    upStatements.push(`ALTER TABLE "${table}" DROP COLUMN "${column}";`);
+    downStatements.push(`ALTER TABLE "${table}" ADD COLUMN "${column}" ${fkType};`);
+    downStatements.push(`ALTER TABLE "${table}" ADD CONSTRAINT "${constraintName}" FOREIGN KEY ("${column}") REFERENCES "${references.references}"("${references.column}") ON DELETE SET NULL;`);
+  }
+
+  // View migrations — views are created AFTER tables (dependency order)
+  const viewSchemas = introspectViews();
+  const currentViewSnapshot = viewSchemasToSnapshot(viewSchemas);
+  const previousViewSnapshot = extractViewsFromSnapshot(previousSnapshot);
+  const viewDiff = diffViewSnapshots(previousViewSnapshot, currentViewSnapshot);
+
+  if (viewDiff.hasChanges) {
+    upStatements.push('');
+    upStatements.push('-- Views');
+    downStatements.push('');
+    downStatements.push('-- Views');
+
+    // Added views
+    for (const name of viewDiff.addedViews) {
+      try {
+        const ddl = buildViewDDL(name, viewSchemas[name], schemas);
+        upStatements.push(ddl + ';');
+        downStatements.unshift(`DROP VIEW IF EXISTS "${viewSchemas[name].viewName}";`);
+      } catch (error) {
+        upStatements.push(`-- WARNING: Could not generate DDL for view '${name}': ${error.message}`);
+      }
+    }
+
+    // Removed views
+    for (const name of viewDiff.removedViews) {
+      upStatements.push(`-- WARNING: View '${name}' was removed. Uncomment to drop view:`);
+      upStatements.push(`-- DROP VIEW IF EXISTS "${previousViewSnapshot[name].viewName}";`);
+      downStatements.push(`-- Recreate view for removed view '${name}' manually if needed`);
+    }
+
+    // Changed views (source or aggregates changed)
+    for (const name of viewDiff.changedViews) {
+      try {
+        const ddl = buildViewDDL(name, viewSchemas[name], schemas);
+        upStatements.push(ddl + ';');
+      } catch (error) {
+        upStatements.push(`-- WARNING: Could not generate DDL for changed view '${name}': ${error.message}`);
+      }
+    }
+  }
+
+  const combinedHasChanges = diff.hasChanges || viewDiff.hasChanges;
+
+  if (!combinedHasChanges) {
+    log.db('No schema changes detected.');
+    return null;
+  }
+
+  // Merge view snapshot into the main snapshot
+  const combinedSnapshot = { ...currentSnapshot };
+  for (const [name, viewSnap] of Object.entries(currentViewSnapshot)) {
+    combinedSnapshot[name] = viewSnap;
+  }
+
+  const sanitizedDescription = description.replace(/\s+/g, '_').replace(/[^a-zA-Z0-9_]/g, '');
+  const timestamp = Math.floor(Date.now() / 1000);
+  const filename = `${timestamp}_${sanitizedDescription}.sql`;
+  const content = `-- UP\n${upStatements.join('\n')}\n\n-- DOWN\n${downStatements.join('\n')}\n`;
+
+  await createFile(path.join(migrationsPath, filename), content);
+  await createFile(path.join(migrationsPath, '.snapshot.json'), JSON.stringify(combinedSnapshot, null, 2));
+
+  log.db(`Migration generated: ${filename}`);
+
+  return { filename, content, snapshot: combinedSnapshot };
+}
+
+export async function loadLatestSnapshot(migrationsPath) {
+  const snapshotPath = path.join(migrationsPath, '.snapshot.json');
+  const exists = await fileExists(snapshotPath);
+
+  if (!exists) return {};
+
+  return readFile(snapshotPath, { json: true });
+}
+
+export function diffSnapshots(previous, current) {
+  const addedModels = [];
+  const removedModels = [];
+  const addedColumns = [];
+  const removedColumns = [];
+  const changedColumns = [];
+  const addedForeignKeys = [];
+  const removedForeignKeys = [];
+
+  // Find added models
+  for (const name of Object.keys(current)) {
+    if (!previous[name]) addedModels.push(name);
+  }
+
+  // Find removed models
+  for (const name of Object.keys(previous)) {
+    if (!current[name]) removedModels.push(name);
+  }
+
+  // Find column changes in existing models
+  for (const name of Object.keys(current)) {
+    if (!previous[name]) continue;
+
+    const { columns: prevCols = {} } = previous[name];
+    const { columns: currCols = {} } = current[name];
+
+    // Added columns
+    for (const [col, type] of Object.entries(currCols)) {
+      if (!prevCols[col]) {
+        addedColumns.push({ model: name, column: col, type });
+      } else if (prevCols[col] !== type) {
+        changedColumns.push({ model: name, column: col, from: prevCols[col], to: type });
+      }
+    }
+
+    // Removed columns
+    for (const [col, type] of Object.entries(prevCols)) {
+      if (!currCols[col]) {
+        removedColumns.push({ model: name, column: col, type });
+      }
+    }
+
+    // Foreign key changes
+    const prevFKs = previous[name].foreignKeys || {};
+    const currFKs = current[name].foreignKeys || {};
+
+    for (const [col, refs] of Object.entries(currFKs)) {
+      if (!prevFKs[col]) {
+        addedForeignKeys.push({ model: name, column: col, references: refs });
+      }
+    }
+
+    for (const [col, refs] of Object.entries(prevFKs)) {
+      if (!currFKs[col]) {
+        removedForeignKeys.push({ model: name, column: col, references: refs });
+      }
+    }
+  }
+
+  const hasChanges = addedModels.length > 0 || removedModels.length > 0 ||
+    addedColumns.length > 0 || removedColumns.length > 0 ||
+    changedColumns.length > 0 || addedForeignKeys.length > 0 || removedForeignKeys.length > 0;
+
+  return {
+    hasChanges,
+    addedModels,
+    removedModels,
+    addedColumns,
+    removedColumns,
+    changedColumns,
+    addedForeignKeys,
+    removedForeignKeys,
+  };
+}
+
+export function detectSchemaDrift(schemas, snapshot) {
+  const current = schemasToSnapshot(schemas);
+  return diffSnapshots(snapshot, current);
+}
+
+export function extractViewsFromSnapshot(snapshot) {
+  const views = {};
+  for (const [name, entry] of Object.entries(snapshot)) {
+    if (entry.isView) views[name] = entry;
+  }
+  return views;
+}
+
+export function diffViewSnapshots(previous, current) {
+  const addedViews = [];
+  const removedViews = [];
+  const changedViews = [];
+
+  for (const name of Object.keys(current)) {
+    if (!previous[name]) {
+      addedViews.push(name);
+    } else if (
+      current[name].viewQuery !== previous[name].viewQuery ||
+      current[name].source !== previous[name].source
+    ) {
+      changedViews.push(name);
+    }
+  }
+
+  for (const name of Object.keys(previous)) {
+    if (!current[name]) {
+      removedViews.push(name);
+    }
+  }
+
+  const hasChanges = addedViews.length > 0 || removedViews.length > 0 || changedViews.length > 0;
+
+  return { hasChanges, addedViews, removedViews, changedViews };
+}

--- a/src/postgres/migration-runner.js
+++ b/src/postgres/migration-runner.js
@@ -1,0 +1,109 @@
+import { readFile, fileExists } from '@stonyx/utils/file';
+import path from 'path';
+import fs from 'fs/promises';
+
+export async function ensureMigrationsTable(pool, tableName = '__migrations') {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS "${tableName}" (
+      id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      filename VARCHAR(255) NOT NULL UNIQUE,
+      applied_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+}
+
+export async function getAppliedMigrations(pool, tableName = '__migrations') {
+  const result = await pool.query(
+    `SELECT filename FROM "${tableName}" ORDER BY id ASC`
+  );
+
+  return result.rows.map(row => row.filename);
+}
+
+export async function getMigrationFiles(migrationsDir) {
+  const exists = await fileExists(migrationsDir);
+  if (!exists) return [];
+
+  const entries = await fs.readdir(migrationsDir);
+
+  return entries
+    .filter(f => f.endsWith('.sql'))
+    .sort();
+}
+
+export function parseMigrationFile(content) {
+  const upMarker = '-- UP';
+  const downMarker = '-- DOWN';
+  const upIndex = content.indexOf(upMarker);
+  const downIndex = content.indexOf(downMarker);
+
+  if (upIndex === -1) {
+    return { up: content.trim(), down: '' };
+  }
+
+  const upStart = upIndex + upMarker.length;
+  const upEnd = downIndex !== -1 ? downIndex : content.length;
+  const up = content.slice(upStart, upEnd).trim();
+  const down = downIndex !== -1 ? content.slice(downIndex + downMarker.length).trim() : '';
+
+  return { up, down };
+}
+
+export async function applyMigration(pool, filename, upSql, tableName = '__migrations') {
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    const statements = splitStatements(upSql);
+
+    for (const stmt of statements) {
+      await client.query(stmt);
+    }
+
+    await client.query(
+      `INSERT INTO "${tableName}" (filename) VALUES ($1)`,
+      [filename]
+    );
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function rollbackMigration(pool, filename, downSql, tableName = '__migrations') {
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    const statements = splitStatements(downSql);
+
+    for (const stmt of statements) {
+      await client.query(stmt);
+    }
+
+    await client.query(
+      `DELETE FROM "${tableName}" WHERE filename = $1`,
+      [filename]
+    );
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+function splitStatements(sql) {
+  return sql
+    .split(';')
+    .map(s => s.trim())
+    .filter(s => s.length > 0 && !s.startsWith('--'));
+}

--- a/src/postgres/postgres-db.js
+++ b/src/postgres/postgres-db.js
@@ -1,0 +1,524 @@
+import { getPool, closePool } from './connection.js';
+import { ensureMigrationsTable, getAppliedMigrations, getMigrationFiles, applyMigration, parseMigrationFile } from './migration-runner.js';
+import { introspectModels, introspectViews, getTopologicalOrder, schemasToSnapshot } from './schema-introspector.js';
+import { loadLatestSnapshot, detectSchemaDrift } from './migration-generator.js';
+import { buildInsert, buildUpdate, buildDelete, buildSelect, buildVectorSearch, buildHybridSearch } from './query-builder.js';
+import { createRecord, store } from '@stonyx/orm';
+import { confirm } from '@stonyx/utils/prompt';
+import { readFile } from '@stonyx/utils/file';
+import { getPluralName } from '../plural-registry.js';
+import config from 'stonyx/config';
+import log from 'stonyx/log';
+import path from 'path';
+
+const defaultDeps = {
+  getPool, closePool, ensureMigrationsTable, getAppliedMigrations,
+  getMigrationFiles, applyMigration, parseMigrationFile,
+  introspectModels, introspectViews, getTopologicalOrder, schemasToSnapshot,
+  loadLatestSnapshot, detectSchemaDrift,
+  buildInsert, buildUpdate, buildDelete, buildSelect, buildVectorSearch, buildHybridSearch,
+  createRecord, store, confirm, readFile, getPluralName, config, log, path
+};
+
+export default class PostgresDB {
+  constructor(deps = {}) {
+    if (PostgresDB.instance) return PostgresDB.instance;
+    PostgresDB.instance = this;
+
+    this.deps = { ...defaultDeps, ...deps };
+    this.pool = null;
+    this.pgConfig = this.deps.config.orm.postgres;
+  }
+
+  async init() {
+    this.pool = await this.deps.getPool(this.pgConfig);
+    await this.deps.ensureMigrationsTable(this.pool, this.pgConfig.migrationsTable);
+    await this.loadMemoryRecords();
+  }
+
+  async startup() {
+    const migrationsPath = this.deps.path.resolve(this.deps.config.rootPath, this.pgConfig.migrationsDir);
+
+    // Check for pending migrations
+    const applied = await this.deps.getAppliedMigrations(this.pool, this.pgConfig.migrationsTable);
+    const files = await this.deps.getMigrationFiles(migrationsPath);
+    const pending = files.filter(f => !applied.includes(f));
+
+    if (pending.length > 0) {
+      this.deps.log.db(`${pending.length} pending migration(s) found.`);
+
+      const shouldApply = await this.deps.confirm(`${pending.length} pending migration(s) found. Apply now?`);
+
+      if (shouldApply) {
+        for (const filename of pending) {
+          const content = await this.deps.readFile(this.deps.path.join(migrationsPath, filename));
+          const { up } = this.deps.parseMigrationFile(content);
+
+          await this.deps.applyMigration(this.pool, filename, up, this.pgConfig.migrationsTable);
+          this.deps.log.db(`Applied migration: ${filename}`);
+        }
+
+        // Reload records after applying migrations
+        await this.loadMemoryRecords();
+      } else {
+        this.deps.log.warn('Skipping pending migrations. Schema may be outdated.');
+      }
+    } else if (files.length === 0) {
+      const schemas = this.deps.introspectModels();
+      const modelCount = Object.keys(schemas).length;
+
+      if (modelCount > 0) {
+        const shouldGenerate = await this.deps.confirm(
+          `No migrations found but ${modelCount} model(s) detected. Generate and apply initial migration?`
+        );
+
+        if (shouldGenerate) {
+          const { generateMigration } = await import('./migration-generator.js');
+          const result = await generateMigration('initial_setup');
+
+          if (result) {
+            const { up } = this.deps.parseMigrationFile(result.content);
+            await this.deps.applyMigration(this.pool, result.filename, up, this.pgConfig.migrationsTable);
+            this.deps.log.db(`Applied migration: ${result.filename}`);
+            await this.loadMemoryRecords();
+          }
+        } else {
+          this.deps.log.warn('Skipping initial migration. Tables may not exist.');
+        }
+      }
+    }
+
+    // Check for schema drift
+    const schemas = this.deps.introspectModels();
+    const snapshot = await this.deps.loadLatestSnapshot(this.deps.path.resolve(this.deps.config.rootPath, this.pgConfig.migrationsDir));
+
+    if (Object.keys(snapshot).length > 0) {
+      const drift = this.deps.detectSchemaDrift(schemas, snapshot);
+
+      if (drift.hasChanges) {
+        this.deps.log.warn('Schema drift detected: models have changed since the last migration.');
+        this.deps.log.warn('Run `stonyx db:generate-migration` to create a new migration.');
+      }
+    }
+  }
+
+  async shutdown() {
+    await this.deps.closePool();
+    this.pool = null;
+  }
+
+  async save() {
+    // No-op: PostgreSQL persists data immediately via persist()
+  }
+
+  /**
+   * Loads only models with memory: true into the in-memory store on startup.
+   * Models with memory: false are skipped — accessed on-demand via find()/findAll().
+   */
+  async loadMemoryRecords() {
+    const schemas = this.deps.introspectModels();
+    const order = this.deps.getTopologicalOrder(schemas);
+    const Orm = (await import('@stonyx/orm')).default;
+
+    for (const modelName of order) {
+      const { modelClass } = Orm.instance.getRecordClasses(modelName);
+      if (modelClass?.memory === false) {
+        this.deps.log.db(`Skipping memory load for '${modelName}' (memory: false)`);
+        continue;
+      }
+
+      const schema = schemas[modelName];
+      const { sql, values } = this.deps.buildSelect(schema.table);
+
+      try {
+        const result = await this.pool.query(sql, values);
+
+        for (const row of result.rows) {
+          const rawData = this._rowToRawData(row, schema);
+          this.deps.createRecord(modelName, rawData, { isDbRecord: true, serialize: false, transform: false });
+        }
+      } catch (error) {
+        // 42P01 = undefined_table (PG equivalent of ER_NO_SUCH_TABLE)
+        if (error.code === '42P01') {
+          this.deps.log.db(`Table '${schema.table}' does not exist yet. Skipping load for '${modelName}'.`);
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    // Load views with memory: true
+    const viewSchemas = this.deps.introspectViews();
+
+    for (const [viewName, viewSchema] of Object.entries(viewSchemas)) {
+      const { modelClass: viewClass } = Orm.instance.getRecordClasses(viewName);
+      if (viewClass?.memory !== true) {
+        this.deps.log.db(`Skipping memory load for view '${viewName}' (memory: false)`);
+        continue;
+      }
+
+      const schema = { table: viewSchema.viewName, columns: viewSchema.columns || {}, foreignKeys: viewSchema.foreignKeys || {} };
+      const { sql, values } = this.deps.buildSelect(schema.table);
+
+      try {
+        const result = await this.pool.query(sql, values);
+
+        for (const row of result.rows) {
+          const rawData = this._rowToRawData(row, schema);
+          this.deps.createRecord(viewName, rawData, { isDbRecord: true, serialize: false, transform: false });
+        }
+      } catch (error) {
+        if (error.code === '42P01') {
+          this.deps.log.db(`View '${viewSchema.viewName}' does not exist yet. Skipping load for '${viewName}'.`);
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * @deprecated Use loadMemoryRecords() instead. Kept for backward compatibility.
+   */
+  async loadAllRecords() {
+    return this.loadMemoryRecords();
+  }
+
+  /**
+   * Find a single record by ID from PostgreSQL.
+   * Does NOT cache the result in the store for memory: false models.
+   * @param {string} modelName
+   * @param {string|number} id
+   * @returns {Promise<Record|undefined>}
+   */
+  async findRecord(modelName, id) {
+    const schemas = this.deps.introspectModels();
+    let schema = schemas[modelName];
+
+    // Check views if not found in models
+    if (!schema) {
+      const viewSchemas = this.deps.introspectViews();
+      const viewSchema = viewSchemas[modelName];
+      if (viewSchema) {
+        schema = { table: viewSchema.viewName, columns: viewSchema.columns || {}, foreignKeys: viewSchema.foreignKeys || {} };
+      }
+    }
+
+    if (!schema) return undefined;
+
+    const { sql, values } = this.deps.buildSelect(schema.table, { id });
+
+    try {
+      const result = await this.pool.query(sql, values);
+
+      if (result.rows.length === 0) return undefined;
+
+      const rawData = this._rowToRawData(result.rows[0], schema);
+      const record = this.deps.createRecord(modelName, rawData, { isDbRecord: true, serialize: false, transform: false });
+
+      this._evictIfNotMemory(modelName, record);
+
+      return record;
+    } catch (error) {
+      if (error.code === '42P01') return undefined;
+      throw error;
+    }
+  }
+
+  /**
+   * Find all records of a model from PostgreSQL, with optional conditions.
+   * @param {string} modelName
+   * @param {Object} [conditions] - Optional WHERE conditions (key-value pairs)
+   * @returns {Promise<Record[]>}
+   */
+  async findAll(modelName, conditions) {
+    const schemas = this.deps.introspectModels();
+    let schema = schemas[modelName];
+
+    // Check views if not found in models
+    if (!schema) {
+      const viewSchemas = this.deps.introspectViews();
+      const viewSchema = viewSchemas[modelName];
+      if (viewSchema) {
+        schema = { table: viewSchema.viewName, columns: viewSchema.columns || {}, foreignKeys: viewSchema.foreignKeys || {} };
+      }
+    }
+
+    if (!schema) return [];
+
+    const { sql, values } = this.deps.buildSelect(schema.table, conditions);
+
+    try {
+      const result = await this.pool.query(sql, values);
+
+      const records = result.rows.map(row => {
+        const rawData = this._rowToRawData(row, schema);
+        return this.deps.createRecord(modelName, rawData, { isDbRecord: true, serialize: false, transform: false });
+      });
+
+      for (const record of records) {
+        this._evictIfNotMemory(modelName, record);
+      }
+
+      return records;
+    } catch (error) {
+      if (error.code === '42P01') return [];
+      throw error;
+    }
+  }
+
+  /**
+   * Perform a vector similarity search using cosine distance.
+   * @param {string} modelName
+   * @param {string} vectorColumn - Name of the vector column
+   * @param {number[]} queryVector - The query vector
+   * @param {Object} [options]
+   * @param {number} [options.limit=10]
+   * @param {Object} [options.where] - Additional conditions
+   * @returns {Promise<{ record: Record, distance: number }[]>}
+   */
+  async vectorSearch(modelName, vectorColumn, queryVector, options = {}) {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+    if (!schema) return [];
+
+    const { sql, values } = this.deps.buildVectorSearch(schema.table, vectorColumn, queryVector, options);
+
+    try {
+      const result = await this.pool.query(sql, values);
+
+      return result.rows.map(row => {
+        const distance = row.distance;
+        delete row.distance;
+        const rawData = this._rowToRawData(row, schema);
+        const record = this.deps.createRecord(modelName, rawData, { isDbRecord: true, serialize: false, transform: false });
+        this._evictIfNotMemory(modelName, record);
+        return { record, distance };
+      });
+    } catch (error) {
+      if (error.code === '42P01') return [];
+      throw error;
+    }
+  }
+
+  /**
+   * Perform a hybrid search combining vector similarity with text filtering.
+   * @param {string} modelName
+   * @param {string} vectorColumn
+   * @param {number[]} queryVector
+   * @param {string} textColumn
+   * @param {string} textQuery
+   * @param {Object} [options]
+   * @returns {Promise<{ record: Record, distance: number }[]>}
+   */
+  async hybridSearch(modelName, vectorColumn, queryVector, textColumn, textQuery, options = {}) {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+    if (!schema) return [];
+
+    const { sql, values } = this.deps.buildHybridSearch(schema.table, vectorColumn, queryVector, textColumn, textQuery, options);
+
+    try {
+      const result = await this.pool.query(sql, values);
+
+      return result.rows.map(row => {
+        const distance = row.distance;
+        delete row.distance;
+        const rawData = this._rowToRawData(row, schema);
+        const record = this.deps.createRecord(modelName, rawData, { isDbRecord: true, serialize: false, transform: false });
+        this._evictIfNotMemory(modelName, record);
+        return { record, distance };
+      });
+    } catch (error) {
+      if (error.code === '42P01') return [];
+      throw error;
+    }
+  }
+
+  /**
+   * Remove a record from the in-memory store if its model has memory: false.
+   * The record object itself survives — the caller retains the reference.
+   * @private
+   */
+  _evictIfNotMemory(modelName, record) {
+    const store = this.deps.store;
+
+    if (store._memoryResolver && !store._memoryResolver(modelName)) {
+      const modelStore = store.get?.(modelName) ?? store.data?.get(modelName);
+      if (modelStore) modelStore.delete(record.id);
+    }
+  }
+
+  _rowToRawData(row, schema) {
+    const rawData = { ...row };
+
+    // PostgreSQL returns native booleans and parsed JSONB — no manual conversion needed.
+    // Only FK remapping and timestamp stripping required.
+
+    // Map FK columns back to relationship keys
+    for (const [fkCol] of Object.entries(schema.foreignKeys)) {
+      const relName = fkCol.replace(/_id$/, '');
+
+      if (rawData[fkCol] !== undefined) {
+        rawData[relName] = rawData[fkCol];
+        delete rawData[fkCol];
+      }
+    }
+
+    // Remove timestamp columns — managed by PostgreSQL
+    delete rawData.created_at;
+    delete rawData.updated_at;
+
+    return rawData;
+  }
+
+  async persist(operation, modelName, context, response) {
+    // Views are read-only — no-op for all write operations
+    const Orm = (await import('@stonyx/orm')).default;
+    if (Orm.instance?.isView?.(modelName)) return;
+
+    switch (operation) {
+      case 'create':
+        return this._persistCreate(modelName, context, response);
+      case 'update':
+        return this._persistUpdate(modelName, context, response);
+      case 'delete':
+        return this._persistDelete(modelName, context);
+    }
+  }
+
+  async _persistCreate(modelName, context, response) {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+
+    if (!schema) return;
+
+    const recordId = response?.data?.id;
+    const record = recordId != null ? this.deps.store.get(modelName, isNaN(recordId) ? recordId : parseInt(recordId)) : null;
+
+    if (!record) return;
+
+    const insertData = this._recordToRow(record, schema);
+
+    // For auto-increment models, remove the pending ID
+    const isPendingId = record.__data.__pendingSqlId;
+
+    if (isPendingId) {
+      delete insertData.id;
+    }
+
+    const { sql, values } = this.deps.buildInsert(schema.table, insertData);
+
+    const result = await this.pool.query(sql, values);
+
+    // Re-key the record in the store if PostgreSQL generated the ID (via RETURNING)
+    if (isPendingId && result.rows.length > 0) {
+      const pendingId = record.id;
+      const realId = result.rows[0].id;
+      const modelStore = this.deps.store.get(modelName);
+
+      modelStore.delete(pendingId);
+      record.__data.id = realId;
+      record.id = realId;
+      modelStore.set(realId, record);
+
+      // Update the response data with the real ID
+      if (response?.data) {
+        response.data.id = realId;
+      }
+
+      delete record.__data.__pendingSqlId;
+    }
+  }
+
+  async _persistUpdate(modelName, context, response) {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+
+    if (!schema) return;
+
+    const record = context.record;
+    if (!record) return;
+
+    const id = record.id;
+    const oldState = context.oldState || {};
+    const currentData = record.__data;
+
+    // Build a diff of changed columns
+    const changedData = {};
+
+    for (const [col] of Object.entries(schema.columns)) {
+      if (currentData[col] !== oldState[col]) {
+        changedData[col] = currentData[col] ?? null;
+      }
+    }
+
+    // Check FK changes too
+    for (const fkCol of Object.keys(schema.foreignKeys)) {
+      const relName = fkCol.replace(/_id$/, '');
+      const currentFkValue = record.__relationships[relName]?.id ?? null;
+      const oldFkValue = oldState[relName] ?? null;
+
+      if (currentFkValue !== oldFkValue) {
+        changedData[fkCol] = currentFkValue;
+      }
+    }
+
+    if (Object.keys(changedData).length === 0) return;
+
+    // PostgreSQL doesn't have ON UPDATE CURRENT_TIMESTAMP — set updated_at manually
+    changedData.updated_at = new Date();
+
+    const { sql, values } = this.deps.buildUpdate(schema.table, id, changedData);
+    await this.pool.query(sql, values);
+  }
+
+  async _persistDelete(modelName, context) {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+
+    if (!schema) return;
+
+    const id = context.recordId;
+    if (id == null) return;
+
+    const { sql, values } = this.deps.buildDelete(schema.table, id);
+    await this.pool.query(sql, values);
+  }
+
+  _recordToRow(record, schema) {
+    const row = {};
+    const data = record.__data;
+
+    // ID
+    if (data.id !== undefined) {
+      row.id = data.id;
+    }
+
+    // Attribute columns
+    for (const [col, pgType] of Object.entries(schema.columns)) {
+      if (data[col] !== undefined) {
+        // JSONB columns: stringify non-string values for PostgreSQL JSONB storage
+        row[col] = pgType === 'JSONB' && typeof data[col] !== 'string'
+          ? JSON.stringify(data[col])
+          : data[col];
+      }
+    }
+
+    // FK columns from relationships
+    for (const fkCol of Object.keys(schema.foreignKeys)) {
+      const relName = fkCol.replace(/_id$/, '');
+      const related = record.__relationships[relName];
+
+      if (related) {
+        row[fkCol] = related.id;
+      } else if (data[relName] !== undefined) {
+        // Raw FK value (e.g., from create payload)
+        row[fkCol] = data[relName];
+      }
+    }
+
+    return row;
+  }
+}

--- a/src/postgres/query-builder.js
+++ b/src/postgres/query-builder.js
@@ -1,0 +1,149 @@
+const SAFE_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+
+export function validateIdentifier(name, context = 'identifier') {
+  if (!name || typeof name !== 'string' || !SAFE_IDENTIFIER.test(name)) {
+    throw new Error(`Invalid SQL ${context}: "${name}". Identifiers must match ${SAFE_IDENTIFIER}`);
+  }
+
+  return name;
+}
+
+export function buildInsert(table, data) {
+  validateIdentifier(table, 'table name');
+
+  const keys = Object.keys(data);
+  keys.forEach(k => validateIdentifier(k, 'column name'));
+
+  const placeholders = keys.map((_, i) => `$${i + 1}`);
+  const values = keys.map(k => data[k]);
+
+  const sql = `INSERT INTO "${table}" (${keys.map(k => `"${k}"`).join(', ')}) VALUES (${placeholders.join(', ')}) RETURNING "id"`;
+
+  return { sql, values };
+}
+
+export function buildUpdate(table, id, data) {
+  validateIdentifier(table, 'table name');
+
+  const keys = Object.keys(data);
+  keys.forEach(k => validateIdentifier(k, 'column name'));
+
+  const setClauses = keys.map((k, i) => `"${k}" = $${i + 1}`);
+  const values = [...keys.map(k => data[k]), id];
+
+  const sql = `UPDATE "${table}" SET ${setClauses.join(', ')} WHERE "id" = $${keys.length + 1}`;
+
+  return { sql, values };
+}
+
+export function buildDelete(table, id) {
+  validateIdentifier(table, 'table name');
+
+  return {
+    sql: `DELETE FROM "${table}" WHERE "id" = $1`,
+    values: [id],
+  };
+}
+
+export function buildSelect(table, conditions) {
+  validateIdentifier(table, 'table name');
+
+  if (!conditions || Object.keys(conditions).length === 0) {
+    return { sql: `SELECT * FROM "${table}"`, values: [] };
+  }
+
+  const keys = Object.keys(conditions);
+  keys.forEach(k => validateIdentifier(k, 'column name'));
+
+  const whereClauses = keys.map((k, i) => `"${k}" = $${i + 1}`);
+  const values = keys.map(k => conditions[k]);
+
+  const sql = `SELECT * FROM "${table}" WHERE ${whereClauses.join(' AND ')}`;
+
+  return { sql, values };
+}
+
+/**
+ * Build a vector similarity search query using cosine distance (<=>).
+ * @param {string} table - Table name
+ * @param {string} vectorColumn - Name of the vector column
+ * @param {number[]} queryVector - The query vector
+ * @param {Object} [options]
+ * @param {number} [options.limit=10] - Number of results to return
+ * @param {Object} [options.where] - Additional WHERE conditions
+ * @returns {{ sql: string, values: any[] }}
+ */
+export function buildVectorSearch(table, vectorColumn, queryVector, options = {}) {
+  validateIdentifier(table, 'table name');
+  validateIdentifier(vectorColumn, 'column name');
+
+  const { limit = 10, where } = options;
+  const values = [];
+  let paramIndex = 1;
+
+  // Vector parameter as a formatted string for pgvector
+  const vectorStr = `[${queryVector.join(',')}]`;
+  values.push(vectorStr);
+  const vectorParam = `$${paramIndex++}`;
+
+  let whereClauses = [];
+  if (where) {
+    for (const [k, v] of Object.entries(where)) {
+      validateIdentifier(k, 'column name');
+      whereClauses.push(`"${k}" = $${paramIndex++}`);
+      values.push(v);
+    }
+  }
+
+  const whereStr = whereClauses.length > 0 ? ` WHERE ${whereClauses.join(' AND ')}` : '';
+  values.push(limit);
+
+  const sql = `SELECT *, ("${vectorColumn}" <=> ${vectorParam}::vector) AS distance FROM "${table}"${whereStr} ORDER BY "${vectorColumn}" <=> ${vectorParam}::vector LIMIT $${paramIndex}`;
+
+  return { sql, values };
+}
+
+/**
+ * Build a hybrid search query combining vector similarity with text filtering.
+ * Uses cosine distance for vector ranking and ILIKE for text matching.
+ * @param {string} table - Table name
+ * @param {string} vectorColumn - Vector column name
+ * @param {number[]} queryVector - The query vector
+ * @param {string} textColumn - Column to search text in
+ * @param {string} textQuery - Text to search for
+ * @param {Object} [options]
+ * @param {number} [options.limit=10]
+ * @param {Object} [options.where] - Additional WHERE conditions
+ * @returns {{ sql: string, values: any[] }}
+ */
+export function buildHybridSearch(table, vectorColumn, queryVector, textColumn, textQuery, options = {}) {
+  validateIdentifier(table, 'table name');
+  validateIdentifier(vectorColumn, 'column name');
+  validateIdentifier(textColumn, 'column name');
+
+  const { limit = 10, where } = options;
+  const values = [];
+  let paramIndex = 1;
+
+  const vectorStr = `[${queryVector.join(',')}]`;
+  values.push(vectorStr);
+  const vectorParam = `$${paramIndex++}`;
+
+  values.push(`%${textQuery}%`);
+  const textParam = `$${paramIndex++}`;
+
+  let whereClauses = [`"${textColumn}" ILIKE ${textParam}`];
+  if (where) {
+    for (const [k, v] of Object.entries(where)) {
+      validateIdentifier(k, 'column name');
+      whereClauses.push(`"${k}" = $${paramIndex++}`);
+      values.push(v);
+    }
+  }
+
+  values.push(limit);
+
+  const sql = `SELECT *, ("${vectorColumn}" <=> ${vectorParam}::vector) AS distance FROM "${table}" WHERE ${whereClauses.join(' AND ')} ORDER BY "${vectorColumn}" <=> ${vectorParam}::vector LIMIT $${paramIndex}`;
+
+  return { sql, values };
+}

--- a/src/postgres/schema-introspector.js
+++ b/src/postgres/schema-introspector.js
@@ -1,0 +1,354 @@
+import Orm from '@stonyx/orm';
+import { getPgType, getVectorType } from './type-map.js';
+import { camelCaseToKebabCase } from '@stonyx/utils/string';
+import { getPluralName } from '../plural-registry.js';
+import { dbKey } from '../db.js';
+import { AggregateProperty } from '../aggregates.js';
+
+function getRelationshipInfo(property) {
+  if (typeof property !== 'function') return null;
+  const fnStr = property.toString();
+  const modelName = property.__relatedModelName || null;
+
+  if (fnStr.includes(`getRelationships('belongsTo',`)) return { type: 'belongsTo', modelName };
+  if (fnStr.includes(`getRelationships('hasMany',`)) return { type: 'hasMany', modelName };
+
+  return null;
+}
+
+function sanitizeTableName(name) {
+  return name.replace(/[-/]/g, '_');
+}
+
+export function introspectModels() {
+  const { models } = Orm.instance;
+  const schemas = {};
+
+  for (const [modelKey, modelClass] of Object.entries(models)) {
+    const name = camelCaseToKebabCase(modelKey.slice(0, -5));
+
+    if (name === dbKey) continue;
+
+    const model = new modelClass(modelKey);
+    const columns = {};
+    const foreignKeys = {};
+    const relationships = { belongsTo: {}, hasMany: {} };
+    const vectorColumns = {};
+    let idType = 'number';
+
+    const transforms = Orm.instance.transforms;
+
+    for (const [key, property] of Object.entries(model)) {
+      if (key.startsWith('__')) continue;
+
+      const relInfo = getRelationshipInfo(property);
+
+      if (relInfo?.type === 'belongsTo') {
+        relationships.belongsTo[key] = relInfo.modelName;
+      } else if (relInfo?.type === 'hasMany') {
+        relationships.hasMany[key] = relInfo.modelName;
+      } else if (property?.constructor?.name === 'ModelProperty') {
+        if (key === 'id') {
+          idType = property.type;
+        } else if (property.type === 'vector') {
+          const dimensions = property.dimensions || 1536;
+          columns[key] = getVectorType(dimensions);
+          vectorColumns[key] = dimensions;
+        } else {
+          columns[key] = getPgType(property.type, transforms[property.type]);
+        }
+      }
+    }
+
+    // Build foreign keys from belongsTo relationships
+    for (const [relName, targetModelName] of Object.entries(relationships.belongsTo)) {
+      const fkColumn = `${relName}_id`;
+      foreignKeys[fkColumn] = {
+        references: sanitizeTableName(getPluralName(targetModelName)),
+        column: 'id',
+      };
+    }
+
+    schemas[name] = {
+      table: sanitizeTableName(getPluralName(name)),
+      idType,
+      columns,
+      foreignKeys,
+      relationships,
+      vectorColumns,
+      memory: modelClass.memory === true,
+    };
+  }
+
+  return schemas;
+}
+
+export function buildTableDDL(name, schema, allSchemas = {}) {
+  const { idType, columns, foreignKeys } = schema;
+  const table = sanitizeTableName(schema.table);
+  const lines = [];
+
+  // Primary key
+  if (idType === 'string') {
+    lines.push('  "id" VARCHAR(255) PRIMARY KEY');
+  } else {
+    lines.push('  "id" INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY');
+  }
+
+  // Attribute columns
+  for (const [col, pgType] of Object.entries(columns)) {
+    lines.push(`  "${col}" ${pgType}`);
+  }
+
+  // Foreign key columns
+  for (const [fkCol, fkDef] of Object.entries(foreignKeys)) {
+    const refIdType = getReferencedIdType(fkDef.references, allSchemas);
+    lines.push(`  "${fkCol}" ${refIdType}`);
+  }
+
+  // Timestamps
+  lines.push('  "created_at" TIMESTAMPTZ DEFAULT NOW()');
+  lines.push('  "updated_at" TIMESTAMPTZ DEFAULT NOW()');
+
+  // Foreign key constraints
+  for (const [fkCol, fkDef] of Object.entries(foreignKeys)) {
+    const refTable = sanitizeTableName(fkDef.references);
+    lines.push(`  FOREIGN KEY ("${fkCol}") REFERENCES "${refTable}"("${fkDef.column}") ON DELETE SET NULL`);
+  }
+
+  return `CREATE TABLE IF NOT EXISTS "${table}" (\n${lines.join(',\n')}\n)`;
+}
+
+/**
+ * Build HNSW index DDL for vector columns on a model.
+ * @param {string} name - Model name
+ * @param {Object} schema - Model schema with vectorColumns
+ * @returns {string[]} Array of CREATE INDEX statements
+ */
+export function buildVectorIndexDDL(name, schema) {
+  const table = sanitizeTableName(schema.table);
+  const statements = [];
+
+  for (const [col] of Object.entries(schema.vectorColumns || {})) {
+    statements.push(
+      `CREATE INDEX IF NOT EXISTS "idx_${table}_${col}_hnsw" ON "${table}" USING hnsw ("${col}" vector_cosine_ops) WITH (m = 16, ef_construction = 200)`
+    );
+  }
+
+  return statements;
+}
+
+function getReferencedIdType(tableName, allSchemas) {
+  for (const schema of Object.values(allSchemas)) {
+    if (schema.table === tableName) {
+      return schema.idType === 'string' ? 'VARCHAR(255)' : 'INTEGER';
+    }
+  }
+
+  return 'INTEGER';
+}
+
+export function getTopologicalOrder(schemas) {
+  const visited = new Set();
+  const order = [];
+
+  function visit(name) {
+    if (visited.has(name)) return;
+    visited.add(name);
+
+    const schema = schemas[name];
+    if (!schema) return;
+
+    // Visit dependencies (belongsTo targets) first
+    for (const targetModelName of Object.values(schema.relationships.belongsTo)) {
+      visit(targetModelName);
+    }
+
+    order.push(name);
+  }
+
+  for (const name of Object.keys(schemas)) {
+    visit(name);
+  }
+
+  return order;
+}
+
+export function introspectViews() {
+  const orm = Orm.instance;
+  if (!orm.views) return {};
+
+  const schemas = {};
+
+  for (const [viewKey, viewClass] of Object.entries(orm.views)) {
+    const name = camelCaseToKebabCase(viewKey.slice(0, -4)); // Remove 'View' suffix
+
+    const source = viewClass.source;
+    if (!source) continue;
+
+    const model = new viewClass(name);
+    const columns = {};
+    const foreignKeys = {};
+    const aggregates = {};
+    const relationships = { belongsTo: {}, hasMany: {} };
+
+    for (const [key, property] of Object.entries(model)) {
+      if (key.startsWith('__')) continue;
+      if (key === 'id') continue;
+
+      if (property instanceof AggregateProperty) {
+        aggregates[key] = property;
+        continue;
+      }
+
+      const relInfo = getRelationshipInfo(property);
+
+      if (relInfo?.type === 'belongsTo') {
+        relationships.belongsTo[key] = relInfo.modelName;
+        const fkColumn = `${key}_id`;
+        foreignKeys[fkColumn] = {
+          references: sanitizeTableName(getPluralName(relInfo.modelName)),
+          column: 'id',
+        };
+      } else if (relInfo?.type === 'hasMany') {
+        relationships.hasMany[key] = relInfo.modelName;
+      } else if (property?.constructor?.name === 'ModelProperty') {
+        const transforms = Orm.instance.transforms;
+        columns[key] = getPgType(property.type, transforms[property.type]);
+      }
+    }
+
+    schemas[name] = {
+      viewName: sanitizeTableName(getPluralName(name)),
+      source,
+      groupBy: viewClass.groupBy || undefined,
+      columns,
+      foreignKeys,
+      aggregates,
+      relationships,
+      isView: true,
+      memory: viewClass.memory !== false ? false : false, // Views default to memory:false
+    };
+  }
+
+  return schemas;
+}
+
+export function buildViewDDL(name, viewSchema, modelSchemas = {}) {
+  if (!viewSchema.source) {
+    throw new Error(`View '${name}' must define a source model`);
+  }
+
+  const sourceModelName = viewSchema.source;
+  const sourceSchema = modelSchemas[sourceModelName];
+  const sourceTable = sanitizeTableName(sourceSchema
+    ? sourceSchema.table
+    : getPluralName(sourceModelName));
+
+  const selectColumns = [];
+  const joins = [];
+  const hasAggregates = Object.keys(viewSchema.aggregates || {}).length > 0;
+  const groupByField = viewSchema.groupBy;
+
+  // ID column: groupBy field or source table PK
+  if (groupByField) {
+    selectColumns.push(`"${sourceTable}"."${groupByField}" AS "id"`);
+  } else {
+    selectColumns.push(`"${sourceTable}"."id" AS "id"`);
+  }
+
+  // Aggregate columns
+  for (const [key, aggProp] of Object.entries(viewSchema.aggregates || {})) {
+    // Use pgFunction if available, fall back to mysqlFunction
+    const fn = aggProp.pgFunction || aggProp.mysqlFunction;
+
+    if (aggProp.relationship === undefined) {
+      // Field-level aggregate (groupBy views)
+      if (aggProp.aggregateType === 'count') {
+        selectColumns.push(`COUNT(*) AS "${key}"`);
+      } else {
+        selectColumns.push(`${fn}("${sourceTable}"."${aggProp.field}") AS "${key}"`);
+      }
+    } else {
+      // Relationship aggregate
+      const relName = aggProp.relationship;
+      const relTable = sanitizeTableName(getPluralName(relName));
+
+      if (aggProp.aggregateType === 'count') {
+        selectColumns.push(`${fn}("${relTable}"."id") AS "${key}"`);
+      } else {
+        const field = aggProp.field;
+        selectColumns.push(`${fn}("${relTable}"."${field}") AS "${key}"`);
+      }
+
+      // Add LEFT JOIN for the relationship if not already added
+      const joinKey = `${relTable}`;
+      if (!joins.find(j => j.table === joinKey)) {
+        const fkColumn = `${sourceModelName}_id`;
+        joins.push({
+          table: relTable,
+          condition: `"${relTable}"."${fkColumn}" = "${sourceTable}"."id"`
+        });
+      }
+    }
+  }
+
+  // Regular columns
+  for (const [key] of Object.entries(viewSchema.columns || {})) {
+    selectColumns.push(`"${sourceTable}"."${key}" AS "${key}"`);
+  }
+
+  // Build JOIN clauses
+  const joinClauses = joins.map(j =>
+    `LEFT JOIN "${j.table}" ON ${j.condition}`
+  ).join('\n  ');
+
+  // Build GROUP BY
+  let groupBy = '';
+  if (groupByField) {
+    groupBy = `\nGROUP BY "${sourceTable}"."${groupByField}"`;
+  } else if (hasAggregates) {
+    groupBy = `\nGROUP BY "${sourceTable}"."id"`;
+  }
+
+  const viewName = sanitizeTableName(viewSchema.viewName);
+  const sql = `CREATE OR REPLACE VIEW "${viewName}" AS\nSELECT\n  ${selectColumns.join(',\n  ')}\nFROM "${sourceTable}"${joinClauses ? '\n  ' + joinClauses : ''}${groupBy}`;
+
+  return sql;
+}
+
+export function viewSchemasToSnapshot(viewSchemas) {
+  const snapshot = {};
+
+  for (const [name, schema] of Object.entries(viewSchemas)) {
+    snapshot[name] = {
+      viewName: schema.viewName,
+      source: schema.source,
+      ...(schema.groupBy ? { groupBy: schema.groupBy } : {}),
+      columns: { ...schema.columns },
+      foreignKeys: { ...schema.foreignKeys },
+      isView: true,
+      viewQuery: buildViewDDL(name, schema),
+    };
+  }
+
+  return snapshot;
+}
+
+export function schemasToSnapshot(schemas) {
+  const snapshot = {};
+
+  for (const [name, schema] of Object.entries(schemas)) {
+    snapshot[name] = {
+      table: schema.table,
+      idType: schema.idType,
+      columns: { ...schema.columns },
+      foreignKeys: { ...schema.foreignKeys },
+      ...(schema.vectorColumns && Object.keys(schema.vectorColumns).length > 0
+        ? { vectorColumns: { ...schema.vectorColumns } }
+        : {}),
+    };
+  }
+
+  return snapshot;
+}

--- a/src/postgres/type-map.js
+++ b/src/postgres/type-map.js
@@ -1,0 +1,53 @@
+const typeMap = {
+  string: 'VARCHAR(255)',
+  number: 'INTEGER',
+  float: 'REAL',
+  boolean: 'BOOLEAN',
+  date: 'TIMESTAMPTZ',
+  timestamp: 'BIGINT',
+  passthrough: 'TEXT',
+  trim: 'VARCHAR(255)',
+  uppercase: 'VARCHAR(255)',
+  ceil: 'INTEGER',
+  floor: 'INTEGER',
+  round: 'INTEGER',
+};
+
+/**
+ * Resolves a Stonyx ORM attribute type to a PostgreSQL column type.
+ *
+ * For built-in types, returns the mapped PostgreSQL type directly.
+ *
+ * For custom transforms (e.g. an `animal` transform that maps strings to ints):
+ *   - If the transform function exports a `pgType` property, that value is used.
+ *   - Otherwise, if `mysqlType` is defined, it is mapped to a PG equivalent.
+ *   - Otherwise, defaults to JSONB. Values are JSON-stringified on write and
+ *     JSON-parsed on read by PostgreSQL natively.
+ */
+export function getPgType(attrType, transformFn) {
+  if (typeMap[attrType]) return typeMap[attrType];
+  if (transformFn?.pgType) return transformFn.pgType;
+  if (transformFn?.mysqlType) return mysqlTypeToPg(transformFn.mysqlType);
+
+  return 'JSONB';
+}
+
+/**
+ * Returns a vector column type for the given dimensions.
+ * @param {number} dimensions - Vector dimensionality (e.g. 768, 1536)
+ * @returns {string}
+ */
+export function getVectorType(dimensions) {
+  return `vector(${dimensions})`;
+}
+
+function mysqlTypeToPg(mysqlType) {
+  const upper = mysqlType.toUpperCase();
+  if (upper === 'TINYINT(1)') return 'BOOLEAN';
+  if (upper === 'INT' || upper === 'INT AUTO_INCREMENT') return 'INTEGER';
+  if (upper === 'DATETIME') return 'TIMESTAMPTZ';
+  if (upper === 'JSON') return 'JSONB';
+  return mysqlType;
+}
+
+export default typeMap;

--- a/test/helpers/pg-test-helper.js
+++ b/test/helpers/pg-test-helper.js
@@ -1,0 +1,101 @@
+// test/helpers/pg-test-helper.js
+import pg from 'pg';
+import { introspectModels, buildTableDDL, buildVectorIndexDDL, getTopologicalOrder } from '../../src/postgres/schema-introspector.js';
+import PostgresDB from '../../src/postgres/postgres-db.js';
+
+const TEST_PG_CONFIG = {
+  host: 'localhost',
+  port: 5433,
+  user: 'postgres',
+  password: 'testpass',
+  database: 'stonyx_test',
+  max: 5,
+};
+
+// Shared pool reference — importable by test files
+// null means PostgreSQL is unavailable — tests should assert.expect(0) and return
+export let pool = null;
+
+/**
+ * Setup PostgreSQL integration test lifecycle.
+ * Must be called AFTER setupIntegrationTests(hooks) so Orm.instance exists.
+ * If PostgreSQL is unreachable, pool stays null and tests should guard with:
+ *   if (!pool) { assert.expect(0); return; }
+ */
+export function setupPgTests(hooks, { tables = [] } = {}) {
+  let tableOrder = [];
+  let tableNames = {};
+
+  hooks.before(async function () {
+    // Check if PostgreSQL is reachable before attempting setup
+    try {
+      const client = new pg.Client(TEST_PG_CONFIG);
+      await client.connect();
+      await client.query('CREATE EXTENSION IF NOT EXISTS vector');
+      await client.end();
+    } catch {
+      // PostgreSQL not available — pool stays null, tests will skip
+      return;
+    }
+
+    // Create pool
+    pool = new pg.Pool(TEST_PG_CONFIG);
+
+    // Reset PostgresDB singleton
+    PostgresDB.instance = null;
+
+    // Introspect schemas from the now-initialized ORM
+    const schemas = introspectModels();
+    const fullOrder = getTopologicalOrder(schemas);
+
+    // Filter to requested tables, maintaining topological order
+    tableOrder = fullOrder.filter(name => tables.includes(name));
+
+    // Cache table name mapping
+    for (const name of tableOrder) {
+      tableNames[name] = schemas[name].table;
+    }
+
+    // Create tables in topological order (parents first)
+    for (const name of tableOrder) {
+      const ddl = buildTableDDL(name, schemas[name], schemas);
+      await pool.query(ddl);
+
+      // Create HNSW indexes for vector columns
+      const indexStatements = buildVectorIndexDDL(name, schemas[name]);
+      for (const stmt of indexStatements) {
+        await pool.query(stmt);
+      }
+    }
+  });
+
+  hooks.beforeEach(function () {
+    PostgresDB.instance = null;
+  });
+
+  hooks.afterEach(async function () {
+    PostgresDB.instance = null;
+    if (!pool) return;
+
+    for (const name of tableOrder) {
+      await pool.query(`TRUNCATE TABLE "${tableNames[name]}" CASCADE`);
+    }
+  });
+
+  hooks.after(async function () {
+    if (!pool) return;
+
+    for (const name of [...tableOrder].reverse()) {
+      await pool.query(`DROP TABLE IF EXISTS "${tableNames[name]}" CASCADE`);
+    }
+
+    if (pool) {
+      await pool.end();
+      pool = null;
+    }
+
+    PostgresDB.instance = null;
+  });
+}
+
+export { TEST_PG_CONFIG };

--- a/test/integration/postgres/stress-test.js
+++ b/test/integration/postgres/stress-test.js
@@ -1,0 +1,415 @@
+import QUnit from 'qunit';
+import pg from 'pg';
+import { TEST_PG_CONFIG } from '../../helpers/pg-test-helper.js';
+
+// Stress test configuration
+const VECTOR_DIM = 128;    // Smaller dims for speed — 768d validated in beatrix-shared#55 benchmark
+const SCALES = [10_000, 50_000, 100_000];
+const CONCURRENT_CONNECTIONS = 50;
+const CONCURRENT_OPS = 10_000;
+const POOL_SIZE = 10;       // Smaller than CONCURRENT_CONNECTIONS to test exhaustion
+const RECALL_K = 10;
+const SOAK_DURATION_MS = 2 * 60 * 1000; // 2 minutes (full 30min soak should be run manually)
+
+let pool = null;
+
+function randomVector(dim) {
+  const vec = new Float32Array(dim);
+  for (let i = 0; i < dim; i++) vec[i] = Math.random() * 2 - 1;
+  return vec;
+}
+
+/**
+ * Generate clustered vectors that mimic real embedding distributions.
+ * Uniform random vectors have degenerate distance distributions in high-d,
+ * making HNSW recall artificially low. Clustered vectors are realistic.
+ */
+const NUM_CLUSTERS = 50;
+const clusterCenters = Array.from({ length: NUM_CLUSTERS }, (_, c) => {
+  const center = new Float32Array(VECTOR_DIM);
+  for (let i = 0; i < VECTOR_DIM; i++) center[i] = Math.sin(c * 17 + i * 7) * 0.8;
+  return center;
+});
+
+function clusteredVector(dim) {
+  const center = clusterCenters[Math.floor(Math.random() * NUM_CLUSTERS)];
+  const vec = new Float32Array(dim);
+  for (let i = 0; i < dim; i++) vec[i] = center[i] + (Math.random() - 0.5) * 0.3;
+  return vec;
+}
+
+function vectorToString(vec) {
+  return `[${Array.from(vec).join(',')}]`;
+}
+
+function cosineDistance(a, b) {
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  return 1 - dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+QUnit.module('[Stress] PostgreSQL + pgvector', function (hooks) {
+  hooks.before(async function () {
+    try {
+      const client = new pg.Client(TEST_PG_CONFIG);
+      await client.connect();
+      await client.query('CREATE EXTENSION IF NOT EXISTS vector');
+      await client.end();
+    } catch {
+      return; // PG unavailable — tests will skip
+    }
+
+    pool = new pg.Pool({ ...TEST_PG_CONFIG, max: POOL_SIZE });
+  });
+
+  hooks.after(async function () {
+    if (!pool) return;
+    // Clean up all stress test tables
+    try {
+      await pool.query('DROP TABLE IF EXISTS stress_vectors CASCADE');
+      await pool.query('DROP TABLE IF EXISTS stress_rw CASCADE');
+      await pool.query('DROP TABLE IF EXISTS stress_pool CASCADE');
+    } catch { /* ignore */ }
+    await pool.end();
+    pool = null;
+  });
+
+  // ── Concurrent Read/Write ───────────────────────────────────────────
+
+  QUnit.test('concurrent read/write: 50 connections, 10K operations', async function (assert) {
+    if (!pool) { assert.expect(0); return; }
+
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS stress_rw (
+        id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        value VARCHAR(255),
+        counter INTEGER DEFAULT 0
+      )
+    `);
+
+    // Seed 100 rows
+    for (let i = 0; i < 100; i++) {
+      await pool.query('INSERT INTO stress_rw (value) VALUES ($1)', [`row-${i}`]);
+    }
+
+    // Create separate pool with higher connection limit for concurrency test
+    const concurrentPool = new pg.Pool({ ...TEST_PG_CONFIG, max: CONCURRENT_CONNECTIONS });
+
+    let writeCount = 0;
+    let readCount = 0;
+    let errorCount = 0;
+    const opsPerWorker = Math.ceil(CONCURRENT_OPS / CONCURRENT_CONNECTIONS);
+
+    const workers = Array.from({ length: CONCURRENT_CONNECTIONS }, (_, workerId) =>
+      (async () => {
+        for (let i = 0; i < opsPerWorker; i++) {
+          try {
+            if (Math.random() < 0.5) {
+              // Write: increment a random row's counter
+              const id = Math.floor(Math.random() * 100) + 1;
+              await concurrentPool.query(
+                'UPDATE stress_rw SET counter = counter + 1 WHERE id = $1',
+                [id]
+              );
+              writeCount++;
+            } else {
+              // Read: select a random row
+              const id = Math.floor(Math.random() * 100) + 1;
+              await concurrentPool.query('SELECT * FROM stress_rw WHERE id = $1', [id]);
+              readCount++;
+            }
+          } catch {
+            errorCount++;
+          }
+        }
+      })()
+    );
+
+    const start = Date.now();
+    await Promise.all(workers);
+    const elapsed = Date.now() - start;
+
+    await concurrentPool.end();
+    await pool.query('DROP TABLE stress_rw');
+
+    const totalOps = writeCount + readCount;
+    const qps = Math.round(totalOps / (elapsed / 1000));
+
+    assert.ok(totalOps >= CONCURRENT_OPS * 0.95, `completed ${totalOps}/${CONCURRENT_OPS} ops`);
+    assert.ok(errorCount < totalOps * 0.01, `error rate ${errorCount}/${totalOps} < 1%`);
+    assert.ok(qps > 0, `throughput: ${qps} ops/sec (${elapsed}ms)`);
+  });
+
+  // ── Vector Search Accuracy ──────────────────────────────────────────
+
+  for (const scale of SCALES) {
+    QUnit.test(`vector search accuracy: recall@${RECALL_K} at ${(scale / 1000)}K scale (${VECTOR_DIM}d)`, async function (assert) {
+      if (!pool) { assert.expect(0); return; }
+
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS stress_vectors (
+          id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+          embedding vector(${VECTOR_DIM})
+        )
+      `);
+
+      // Batch insert clustered vectors (realistic embedding distribution)
+      const BATCH_SIZE = 1000;
+      const allVectors = []; // Store for brute-force comparison (Float32Arrays are compact)
+
+      for (let batch = 0; batch < scale / BATCH_SIZE; batch++) {
+        const values = [];
+        const params = [];
+
+        for (let i = 0; i < BATCH_SIZE; i++) {
+          const vec = clusteredVector(VECTOR_DIM);
+          allVectors.push(vec);
+          params.push(`($${i + 1}::vector)`);
+          values.push(vectorToString(vec));
+        }
+
+        await pool.query(
+          `INSERT INTO stress_vectors (embedding) VALUES ${params.join(', ')}`,
+          values
+        );
+      }
+
+      // Create HNSW index
+      const indexStart = Date.now();
+      await pool.query(`
+        CREATE INDEX IF NOT EXISTS idx_stress_hnsw
+        ON stress_vectors USING hnsw (embedding vector_cosine_ops)
+        WITH (m = 16, ef_construction = 200)
+      `);
+      const indexTime = Date.now() - indexStart;
+
+      // Use a dedicated client so SET hnsw.ef_search persists across queries
+      // (pool rotates connections, losing session-level settings)
+      const client = await pool.connect();
+      await client.query('SET hnsw.ef_search = 400');
+
+      // Run 10 random query vectors and measure recall
+      const NUM_QUERIES = 10;
+      let totalRecall = 0;
+
+      for (let q = 0; q < NUM_QUERIES; q++) {
+        const queryVec = clusteredVector(VECTOR_DIM);
+        const queryStr = vectorToString(queryVec);
+
+        // HNSW search
+        const result = await client.query(
+          `SELECT id, (embedding <=> $1::vector) AS distance
+           FROM stress_vectors
+           ORDER BY embedding <=> $1::vector
+           LIMIT $2`,
+          [queryStr, RECALL_K]
+        );
+        const hnswIds = new Set(result.rows.map(r => r.id));
+
+        // Brute-force ground truth
+        const distances = allVectors.map((vec, idx) => ({
+          id: idx + 1, // 1-indexed to match PG IDENTITY
+          distance: cosineDistance(queryVec, vec),
+        }));
+        distances.sort((a, b) => a.distance - b.distance);
+        const truthIds = new Set(distances.slice(0, RECALL_K).map(d => d.id));
+
+        // Recall = intersection / k
+        let hits = 0;
+        for (const id of hnswIds) {
+          if (truthIds.has(id)) hits++;
+        }
+        totalRecall += hits / RECALL_K;
+      }
+
+      client.release();
+      const avgRecall = totalRecall / NUM_QUERIES;
+
+      // Clean up table for next scale
+      await pool.query('DROP TABLE stress_vectors');
+
+      assert.ok(avgRecall >= 0.90, `recall@${RECALL_K} = ${(avgRecall * 100).toFixed(1)}% (>= 90% required)`);
+      assert.ok(indexTime > 0, `HNSW index built in ${indexTime}ms for ${scale} vectors`);
+    });
+  }
+
+  // ── HNSW Index Rebuild Performance ──────────────────────────────────
+
+  QUnit.test('HNSW index rebuild performance', async function (assert) {
+    if (!pool) { assert.expect(0); return; }
+
+    const REBUILD_SCALE = 50_000;
+
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS stress_vectors (
+        id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        embedding vector(${VECTOR_DIM})
+      )
+    `);
+
+    // Insert vectors
+    const BATCH_SIZE = 1000;
+    for (let batch = 0; batch < REBUILD_SCALE / BATCH_SIZE; batch++) {
+      const values = [];
+      const params = [];
+      for (let i = 0; i < BATCH_SIZE; i++) {
+        params.push(`($${i + 1}::vector)`);
+        values.push(vectorToString(randomVector(VECTOR_DIM)));
+      }
+      await pool.query(
+        `INSERT INTO stress_vectors (embedding) VALUES ${params.join(', ')}`,
+        values
+      );
+    }
+
+    // Build index
+    const buildStart = Date.now();
+    await pool.query(`
+      CREATE INDEX idx_stress_rebuild_hnsw
+      ON stress_vectors USING hnsw (embedding vector_cosine_ops)
+      WITH (m = 16, ef_construction = 200)
+    `);
+    const buildTime = Date.now() - buildStart;
+
+    // Drop and rebuild
+    await pool.query('DROP INDEX idx_stress_rebuild_hnsw');
+
+    const rebuildStart = Date.now();
+    await pool.query(`
+      CREATE INDEX idx_stress_rebuild_hnsw
+      ON stress_vectors USING hnsw (embedding vector_cosine_ops)
+      WITH (m = 16, ef_construction = 200)
+    `);
+    const rebuildTime = Date.now() - rebuildStart;
+
+    await pool.query('DROP TABLE stress_vectors');
+
+    assert.ok(buildTime > 0, `initial build: ${buildTime}ms for ${REBUILD_SCALE} vectors`);
+    assert.ok(rebuildTime > 0, `rebuild: ${rebuildTime}ms for ${REBUILD_SCALE} vectors`);
+    // Rebuild should be roughly comparable to initial build (±50%)
+    const ratio = rebuildTime / buildTime;
+    assert.ok(ratio < 2.0, `rebuild/build ratio: ${ratio.toFixed(2)}x (< 2.0x)`);
+  });
+
+  // ── Connection Pool Exhaustion/Recovery ─────────────────────────────
+
+  QUnit.test('connection pool exhaustion and recovery', async function (assert) {
+    if (!pool) { assert.expect(0); return; }
+
+    // Create a pool with very limited connections
+    const smallPool = new pg.Pool({ ...TEST_PG_CONFIG, max: 3, connectionTimeoutMillis: 5000 });
+
+    await smallPool.query(`
+      CREATE TABLE IF NOT EXISTS stress_pool (
+        id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        value TEXT
+      )
+    `);
+
+    // Exhaust pool with long-running queries
+    const longQueries = Array.from({ length: 3 }, () =>
+      smallPool.query('SELECT pg_sleep(1)')
+    );
+
+    // While pool is exhausted, try more queries — they should queue, not fail
+    let queuedSucceeded = 0;
+    let queuedFailed = 0;
+
+    const queuedQueries = Array.from({ length: 5 }, () =>
+      smallPool.query("INSERT INTO stress_pool (value) VALUES ('queued')")
+        .then(() => { queuedSucceeded++; })
+        .catch(() => { queuedFailed++; })
+    );
+
+    // Wait for everything to complete
+    await Promise.all([...longQueries, ...queuedQueries]);
+
+    // Verify pool recovered — run a simple query
+    const result = await smallPool.query('SELECT COUNT(*) as cnt FROM stress_pool');
+    const count = parseInt(result.rows[0].cnt);
+
+    await smallPool.query('DROP TABLE stress_pool');
+    await smallPool.end();
+
+    assert.strictEqual(queuedSucceeded, 5, 'all queued queries succeeded after pool freed');
+    assert.strictEqual(queuedFailed, 0, 'no queued queries failed');
+    assert.strictEqual(count, 5, 'all queued inserts persisted');
+  });
+
+  // ── Memory Usage Under Sustained Load ───────────────────────────────
+
+  QUnit.test('memory stability under sustained vector operations (2min soak)', async function (assert) {
+    if (!pool) { assert.expect(0); return; }
+
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS stress_vectors (
+        id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        embedding vector(${VECTOR_DIM}),
+        label VARCHAR(255)
+      )
+    `);
+
+    // Create HNSW index
+    await pool.query(`
+      CREATE INDEX idx_stress_soak_hnsw
+      ON stress_vectors USING hnsw (embedding vector_cosine_ops)
+      WITH (m = 16, ef_construction = 200)
+    `);
+
+    const startMemory = process.memoryUsage().heapUsed;
+    const startTime = Date.now();
+    let insertCount = 0;
+    let searchCount = 0;
+    let peakMemory = startMemory;
+
+    // Sustained mixed workload: insert + search
+    while (Date.now() - startTime < SOAK_DURATION_MS) {
+      // Batch insert 100 vectors
+      const values = [];
+      const params = [];
+      for (let i = 0; i < 100; i++) {
+        const paramBase = i * 2;
+        params.push(`($${paramBase + 1}::vector, $${paramBase + 2})`);
+        values.push(vectorToString(randomVector(VECTOR_DIM)), `label-${insertCount + i}`);
+      }
+      await pool.query(
+        `INSERT INTO stress_vectors (embedding, label) VALUES ${params.join(', ')}`,
+        values
+      );
+      insertCount += 100;
+
+      // Run 10 vector searches
+      for (let s = 0; s < 10; s++) {
+        const queryStr = vectorToString(randomVector(VECTOR_DIM));
+        await pool.query(
+          `SELECT id, (embedding <=> $1::vector) AS distance
+           FROM stress_vectors
+           ORDER BY embedding <=> $1::vector
+           LIMIT 10`,
+          [queryStr]
+        );
+        searchCount++;
+      }
+
+      // Track peak memory
+      const currentMemory = process.memoryUsage().heapUsed;
+      if (currentMemory > peakMemory) peakMemory = currentMemory;
+    }
+
+    const endMemory = process.memoryUsage().heapUsed;
+    const memoryGrowthMB = (peakMemory - startMemory) / (1024 * 1024);
+    const elapsed = Date.now() - startTime;
+
+    await pool.query('DROP TABLE stress_vectors');
+
+    assert.ok(insertCount > 0, `inserted ${insertCount} vectors in ${(elapsed / 1000).toFixed(0)}s`);
+    assert.ok(searchCount > 0, `ran ${searchCount} vector searches`);
+    // Memory growth should be bounded — not leaking. Allow up to 200MB growth
+    // (Node GC is non-deterministic, so we're generous)
+    assert.ok(memoryGrowthMB < 200, `memory growth: ${memoryGrowthMB.toFixed(1)}MB (< 200MB limit)`);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds complete PostgreSQL adapter in `src/postgres/` (7 files) parallel to the existing MySQL adapter, with `$N` parameterized queries, double-quote identifiers, `GENERATED ALWAYS AS IDENTITY`, native `BOOLEAN`/`JSONB`/`TIMESTAMPTZ`, and PG transaction semantics
- Implements pgvector-powered `vectorSearch()` and `hybridSearch()` methods using cosine distance (`<=>`) with automatic HNSW index generation (`m=16, ef_construction=200`)
- Wires PG adapter dispatch in `main.js` (prioritized when `PG_HOST` is set), adds `PG_*` env config in `environment.js`, and `pg ^8.0.0` as optional peer dep
- Includes comprehensive stress tests validating driver under load against pgvector Docker container

Closes #45

## Test plan
- [x] All 507 existing tests pass (zero regressions)
- [x] Concurrent R/W: 50 connections, 10K ops, <1% error rate
- [x] Vector search recall@10 >= 90% at 10K/50K/100K scale
- [x] HNSW index rebuild performance (rebuild/build ratio < 2x)
- [x] Connection pool exhaustion/recovery (queued queries succeed)
- [x] 2-minute soak test — memory growth < 200MB under sustained load
- [x] Full suite: 514/514 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)