### PR TITLE
refactor: add requirePool() accessor to eliminate non-null assertions

### DIFF
--- a/src/mysql/mysql-db.ts
+++ b/src/mysql/mysql-db.ts
@@ -95,6 +95,11 @@ export default class MysqlDB {
     this.mysqlConfig = this.deps.config.orm.mysql;
   }
 
+  private requirePool(): Pool {
+    if (!this.pool) throw new Error('MysqlDB pool not initialized — call init() first');
+    return this.pool;
+  }
+
   async init(): Promise<void> {
     this.pool = await this.deps.getPool(this.mysqlConfig);
     await this.deps.ensureMigrationsTable(this.pool, this.mysqlConfig.migrationsTable);
@@ -105,7 +110,7 @@ export default class MysqlDB {
     const migrationsPath = this.deps.path.resolve(this.deps.config.rootPath, this.mysqlConfig.migrationsDir!);
 
     // Check for pending migrations
-    const applied = await this.deps.getAppliedMigrations(this.pool!, this.mysqlConfig.migrationsTable);
+    const applied = await this.deps.getAppliedMigrations(this.requirePool(), this.mysqlConfig.migrationsTable);
     const files = await this.deps.getMigrationFiles(migrationsPath);
     const pending = files.filter(f => !applied.includes(f));
 
@@ -119,7 +124,7 @@ export default class MysqlDB {
           const content = await this.deps.readFile(this.deps.path.join(migrationsPath, filename)) as string;
           const { up } = this.deps.parseMigrationFile(content);
 
-          await this.deps.applyMigration(this.pool!, filename, up, this.mysqlConfig.migrationsTable);
+          await this.deps.applyMigration(this.requirePool(), filename, up, this.mysqlConfig.migrationsTable);
           this.deps.log.db!(`Applied migration: ${filename}`);
         }
 
@@ -143,7 +148,7 @@ export default class MysqlDB {
 
           if (result) {
             const { up } = this.deps.parseMigrationFile(result.content);
-            await this.deps.applyMigration(this.pool!, result.filename, up, this.mysqlConfig.migrationsTable);
+            await this.deps.applyMigration(this.requirePool(), result.filename, up, this.mysqlConfig.migrationsTable);
             this.deps.log.db!(`Applied migration: ${result.filename}`);
             await this.loadMemoryRecords();
           }
@@ -197,7 +202,7 @@ export default class MysqlDB {
       const { sql, values } = this.deps.buildSelect(schema.table);
 
       try {
-        const [rows] = await this.pool!.execute(sql, values) as [Record<string, unknown>[], unknown];
+        const [rows] = await this.requirePool().execute(sql, values) as [Record<string, unknown>[], unknown];
 
         for (const row of rows) {
           const rawData = this._rowToRawData(row, schema);
@@ -228,7 +233,7 @@ export default class MysqlDB {
       const { sql, values } = this.deps.buildSelect(schema.table);
 
       try {
-        const [rows] = await this.pool!.execute(sql, values) as [Record<string, unknown>[], unknown];
+        const [rows] = await this.requirePool().execute(sql, values) as [Record<string, unknown>[], unknown];
 
         for (const row of rows) {
           const rawData = this._rowToRawData(row, schema);
@@ -273,7 +278,7 @@ export default class MysqlDB {
     const { sql, values } = this.deps.buildSelect(schema.table, { id });
 
     try {
-      const [rows] = await this.pool!.execute(sql, values) as [Record<string, unknown>[], unknown];
+      const [rows] = await this.requirePool().execute(sql, values) as [Record<string, unknown>[], unknown];
 
       if (rows.length === 0) return undefined;
 
@@ -312,7 +317,7 @@ export default class MysqlDB {
     const { sql, values } = this.deps.buildSelect(schema.table, conditions);
 
     try {
-      const [rows] = await this.pool!.execute(sql, values) as [Record<string, unknown>[], unknown];
+      const [rows] = await this.requirePool().execute(sql, values) as [Record<string, unknown>[], unknown];
 
       const records = rows.map(row => {
         const rawData = this._rowToRawData(row, schema!);
@@ -420,7 +425,7 @@ export default class MysqlDB {
 
     const { sql, values } = this.deps.buildInsert(schema.table, insertData);
 
-    const [result] = await this.pool!.execute(sql, values) as [ExecuteResult, unknown];
+    const [result] = await this.requirePool().execute(sql, values) as [ExecuteResult, unknown];
 
     // Re-key the record in the store if MySQL generated the ID
     if (isPendingId && result.insertId) {
@@ -478,7 +483,7 @@ export default class MysqlDB {
     if (Object.keys(changedData).length === 0) return;
 
     const { sql, values } = this.deps.buildUpdate(schema.table, id, changedData);
-    await this.pool!.execute(sql, values);
+    await this.requirePool().execute(sql, values);
   }
 
   private async _persistDelete(modelName: string, context: PersistContext): Promise<void> {
@@ -491,7 +496,7 @@ export default class MysqlDB {
     if (id == null) return;
 
     const { sql, values } = this.deps.buildDelete(schema.table, id);
-    await this.pool!.execute(sql, values);
+    await this.requirePool().execute(sql, values);
   }
 
   _recordToRow(record: OrmRecord, schema: ModelSchema): Record<string, unknown> {

--- a/src/postgres/postgres-db.ts
+++ b/src/postgres/postgres-db.ts
@@ -128,6 +128,11 @@ export default class PostgresDB {
     this.pgConfig = (this.deps.config as Record<string, Record<string, unknown>>).orm[Ctor.configKey] as Record<string, unknown>;
   }
 
+  protected requirePool(): Pool {
+    if (!this.pool) throw new Error('PostgresDB pool not initialized — call init() first');
+    return this.pool;
+  }
+
   async init(): Promise<void> {
     this.pool = await this.deps.getPool(
       this.pgConfig as unknown as Parameters<typeof getPool>[0],
@@ -141,7 +146,7 @@ export default class PostgresDB {
     const migrationsPath = this.deps.path.resolve(this.deps.config.rootPath as string, this.pgConfig.migrationsDir as string);
 
     // Check for pending migrations
-    const applied = await this.deps.getAppliedMigrations(this.pool!, this.pgConfig.migrationsTable as string | undefined);
+    const applied = await this.deps.getAppliedMigrations(this.requirePool(), this.pgConfig.migrationsTable as string | undefined);
     const files = await this.deps.getMigrationFiles(migrationsPath);
     const pending = files.filter(f => !applied.includes(f));
 
@@ -155,7 +160,7 @@ export default class PostgresDB {
           const content = await this.deps.readFile(this.deps.path.join(migrationsPath, filename)) as string;
           const { up } = this.deps.parseMigrationFile(content);
 
-          await this.deps.applyMigration(this.pool!, filename, up, this.pgConfig.migrationsTable as string | undefined);
+          await this.deps.applyMigration(this.requirePool(), filename, up, this.pgConfig.migrationsTable as string | undefined);
           this.deps.log.db!(`Applied migration: ${filename}`);
         }
 
@@ -179,7 +184,7 @@ export default class PostgresDB {
 
           if (result) {
             const { up } = this.deps.parseMigrationFile(result.content);
-            await this.deps.applyMigration(this.pool!, result.filename, up, this.pgConfig.migrationsTable as string | undefined);
+            await this.deps.applyMigration(this.requirePool(), result.filename, up, this.pgConfig.migrationsTable as string | undefined);
             this.deps.log.db!(`Applied migration: ${result.filename}`);
             await this.loadMemoryRecords();
           }
@@ -232,7 +237,7 @@ export default class PostgresDB {
       const { sql, values } = this.deps.buildSelect(schema.table);
 
       try {
-        const result = await this.pool!.query(sql, values);
+        const result = await this.requirePool().query(sql, values);
 
         for (const row of result.rows) {
           const rawData = this._rowToRawData(row, schema);
@@ -271,7 +276,7 @@ export default class PostgresDB {
       const { sql, values } = this.deps.buildSelect(schema.table);
 
       try {
-        const result = await this.pool!.query(sql, values);
+        const result = await this.requirePool().query(sql, values);
 
         for (const row of result.rows) {
           const rawData = this._rowToRawData(row, schema);
@@ -324,7 +329,7 @@ export default class PostgresDB {
     const { sql, values } = this.deps.buildSelect(schema.table, { id });
 
     try {
-      const result = await this.pool!.query(sql, values);
+      const result = await this.requirePool().query(sql, values);
 
       if (result.rows.length === 0) return undefined;
 
@@ -369,7 +374,7 @@ export default class PostgresDB {
     const { sql, values } = this.deps.buildSelect(schema.table, conditions);
 
     try {
-      const result = await this.pool!.query(sql, values);
+      const result = await this.requirePool().query(sql, values);
 
       const records = result.rows.map(row => {
         const rawData = this._rowToRawData(row, schema!);
@@ -398,7 +403,7 @@ export default class PostgresDB {
     const { sql, values } = this.deps.buildVectorSearch(schema.table, vectorColumn, queryVector, options);
 
     try {
-      const result = await this.pool!.query(sql, values);
+      const result = await this.requirePool().query(sql, values);
 
       return result.rows.map(row => {
         const distance = row.distance as number;
@@ -425,7 +430,7 @@ export default class PostgresDB {
     const { sql, values } = this.deps.buildHybridSearch(schema.table, vectorColumn, queryVector, textColumn, textQuery, options);
 
     try {
-      const result = await this.pool!.query(sql, values);
+      const result = await this.requirePool().query(sql, values);
 
       return result.rows.map(row => {
         const distance = row.distance as number;
@@ -522,7 +527,7 @@ export default class PostgresDB {
 
     const { sql, values } = this.deps.buildInsert(schema.table, insertData);
 
-    const result = await this.pool!.query(sql, values);
+    const result = await this.requirePool().query(sql, values);
 
     // Re-key the record in the store if PostgreSQL generated the ID (via RETURNING)
     if (isPendingId && result.rows.length > 0) {
@@ -583,7 +588,7 @@ export default class PostgresDB {
     changedData.updated_at = new Date();
 
     const { sql, values } = this.deps.buildUpdate(schema.table, id, changedData);
-    await this.pool!.query(sql, values);
+    await this.requirePool().query(sql, values);
   }
 
   async _persistDelete(modelName: string, context: PersistContext): Promise<void> {
@@ -596,7 +601,7 @@ export default class PostgresDB {
     if (id == null) return;
 
     const { sql, values } = this.deps.buildDelete(schema.table, id);
-    await this.pool!.query(sql, values);
+    await this.requirePool().query(sql, values);
   }
 
   _recordToRow(record: OrmRecord, schema: ModelSchema): Record<string, unknown> {

--- a/src/timescale/timescale-db.ts
+++ b/src/timescale/timescale-db.ts
@@ -46,7 +46,7 @@ export default class TimescaleDB extends PostgresDB {
     if (!schema) throw new Error(`Model '${modelName}' not found`);
 
     const { sql } = (this.deps as unknown as { buildCreateHypertable: typeof buildCreateHypertable }).buildCreateHypertable(schema.table, timeColumn, options);
-    await this.pool!.query(sql);
+    await this.requirePool().query(sql);
   }
 
   /**
@@ -60,7 +60,7 @@ export default class TimescaleDB extends PostgresDB {
     const { sql, values } = (this.deps as unknown as { buildTimeBucket: typeof buildTimeBucket }).buildTimeBucket(schema.table, timeColumn, bucketSize, options);
 
     try {
-      const result = await this.pool!.query(sql, values);
+      const result = await this.requirePool().query(sql, values);
       return result.rows;
     } catch (error) {
       if ((error as { code?: string }).code === '42P01') return [];
@@ -77,7 +77,7 @@ export default class TimescaleDB extends PostgresDB {
     if (!schema) throw new Error(`Model '${modelName}' not found`);
 
     const { sql } = (this.deps as unknown as { buildContinuousAggregate: typeof buildContinuousAggregate }).buildContinuousAggregate(viewName, schema.table, timeColumn, bucketSize, aggregates, options);
-    await this.pool!.query(sql);
+    await this.requirePool().query(sql);
   }
 
   /**
@@ -89,7 +89,7 @@ export default class TimescaleDB extends PostgresDB {
     if (!schema) throw new Error(`Model '${modelName}' not found`);
 
     const { sql } = (this.deps as unknown as { buildEnableCompression: typeof buildEnableCompression }).buildEnableCompression(schema.table, options.segmentBy, options.orderBy);
-    await this.pool!.query(sql);
+    await this.requirePool().query(sql);
   }
 
   /**
@@ -101,6 +101,6 @@ export default class TimescaleDB extends PostgresDB {
     if (!schema) throw new Error(`Model '${modelName}' not found`);
 
     const { sql } = (this.deps as unknown as { buildCompressionPolicy: typeof buildCompressionPolicy }).buildCompressionPolicy(schema.table, compressAfter);
-    await this.pool!.query(sql);
+    await this.requirePool().query(sql);
   }
 }


### PR DESCRIPTION
## Summary
- Adds `requirePool()` method to `MysqlDB` (private) and `PostgresDB` (protected, for TimescaleDB inheritance) that throws a clear error if the pool is null
- Replaces all `this.pool!` non-null assertions across `mysql-db.ts`, `postgres-db.ts`, and `timescale-db.ts` with `this.requirePool()`
- Pool property remains typed as `Pool | null` (set in `init()`, nulled in `shutdown()`)

## Validation
- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run build` — exit 0
- [x] `grep -r "this\.pool!" src/` — 0 matches

Closes #55