### PR TITLE
refactor: add isDbError type guard, replace unsafe error casts (#59)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,7 @@ async function loadConfig(args: string[]): Promise<CLIConfig> {
       const content = await fs.readFile(configPath, 'utf-8');
       Object.assign(config, JSON.parse(content));
     } catch (err) {
-      console.error(`Error reading config file '${configPath}': ${(err as Error).message}`);
+      console.error(`Error reading config file '${configPath}': ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);
     }
 
@@ -175,7 +175,7 @@ async function run(): Promise<void> {
         process.exit(1);
     }
   } catch (err) {
-    console.error(`Error: ${(err as Error).message}`);
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
   }
 }

--- a/src/meta-request.ts
+++ b/src/meta-request.ts
@@ -44,7 +44,7 @@ export default class MetaRequest extends Request {
 
             return metadata;
           } catch (error) {
-            return { error: (error as Error).message };
+            return { error: error instanceof Error ? error.message : String(error) };
           }
         },
       },

--- a/src/mysql/migration-generator.ts
+++ b/src/mysql/migration-generator.ts
@@ -159,7 +159,7 @@ export async function generateMigration(description: string = 'migration'): Prom
         upStatements.push(ddl + ';');
         downStatements.unshift(`DROP VIEW IF EXISTS \`${viewSchemas[name].viewName}\`;`);
       } catch (error) {
-        upStatements.push(`-- WARNING: Could not generate DDL for view '${name}': ${(error as Error).message}`);
+        upStatements.push(`-- WARNING: Could not generate DDL for view '${name}': ${error instanceof Error ? error.message : String(error)}`);
       }
     }
 
@@ -176,7 +176,7 @@ export async function generateMigration(description: string = 'migration'): Prom
         const ddl = buildViewDDL(name, viewSchemas[name], schemas);
         upStatements.push(ddl + ';');
       } catch (error) {
-        upStatements.push(`-- WARNING: Could not generate DDL for changed view '${name}': ${(error as Error).message}`);
+        upStatements.push(`-- WARNING: Could not generate DDL for changed view '${name}': ${error instanceof Error ? error.message : String(error)}`);
       }
     }
   }

--- a/src/mysql/mysql-db.ts
+++ b/src/mysql/mysql-db.ts
@@ -10,6 +10,7 @@ import { createRecord } from '../manage-record.js';
 import { confirm } from '@stonyx/utils/prompt';
 import { readFile } from '@stonyx/utils/file';
 import { getPluralName } from '../plural-registry.js';
+import { isDbError } from '../utils.js';
 import config from 'stonyx/config';
 import log from 'stonyx/log';
 import path from 'path';
@@ -205,7 +206,7 @@ export default class MysqlDB {
         }
       } catch (error) {
         // Table may not exist yet (pre-migration) — skip gracefully
-        if ((error as { code?: string }).code === 'ER_NO_SUCH_TABLE') {
+        if (isDbError(error) && error.code === 'ER_NO_SUCH_TABLE') {
           this.deps.log.db!(`Table '${schema.table}' does not exist yet. Skipping load for '${modelName}'.`);
           continue;
         }
@@ -235,7 +236,7 @@ export default class MysqlDB {
           this.deps.createRecord(viewName, rawData, { isDbRecord: true, serialize: false, transform: false });
         }
       } catch (error) {
-        if ((error as { code?: string }).code === 'ER_NO_SUCH_TABLE') {
+        if (isDbError(error) && error.code === 'ER_NO_SUCH_TABLE') {
           this.deps.log.db!(`View '${viewSchema.viewName}' does not exist yet. Skipping load for '${viewName}'.`);
           continue;
         }
@@ -286,7 +287,7 @@ export default class MysqlDB {
 
       return record;
     } catch (error) {
-      if ((error as { code?: string }).code === 'ER_NO_SUCH_TABLE') return undefined;
+      if (isDbError(error) && error.code === 'ER_NO_SUCH_TABLE') return undefined;
       throw error;
     }
   }
@@ -326,7 +327,7 @@ export default class MysqlDB {
 
       return records;
     } catch (error) {
-      if ((error as { code?: string }).code === 'ER_NO_SUCH_TABLE') return [];
+      if (isDbError(error) && error.code === 'ER_NO_SUCH_TABLE') return [];
       throw error;
     }
   }

--- a/src/postgres/migration-generator.ts
+++ b/src/postgres/migration-generator.ts
@@ -189,7 +189,7 @@ export async function generateMigration(description: string = 'migration', confi
         upStatements.push(ddl + ';');
         downStatements.unshift(`DROP VIEW IF EXISTS "${viewSchemas[name].viewName}";`);
       } catch (error) {
-        upStatements.push(`-- WARNING: Could not generate DDL for view '${name}': ${(error as Error).message}`);
+        upStatements.push(`-- WARNING: Could not generate DDL for view '${name}': ${error instanceof Error ? error.message : String(error)}`);
       }
     }
 
@@ -206,7 +206,7 @@ export async function generateMigration(description: string = 'migration', confi
         const ddl = buildViewDDL(name, viewSchemas[name], schemas);
         upStatements.push(ddl + ';');
       } catch (error) {
-        upStatements.push(`-- WARNING: Could not generate DDL for changed view '${name}': ${(error as Error).message}`);
+        upStatements.push(`-- WARNING: Could not generate DDL for changed view '${name}': ${error instanceof Error ? error.message : String(error)}`);
       }
     }
   }

--- a/src/postgres/postgres-db.ts
+++ b/src/postgres/postgres-db.ts
@@ -8,6 +8,7 @@ import { createRecord } from '../manage-record.js';
 import { confirm } from '@stonyx/utils/prompt';
 import { readFile } from '@stonyx/utils/file';
 import { getPluralName } from '../plural-registry.js';
+import { isDbError } from '../utils.js';
 import config from 'stonyx/config';
 import log from 'stonyx/log';
 import path from 'path';
@@ -240,7 +241,7 @@ export default class PostgresDB {
         }
       } catch (error) {
         // 42P01 = undefined_table (PG equivalent of ER_NO_SUCH_TABLE)
-        if ((error as { code?: string }).code === '42P01') {
+        if (isDbError(error) && error.code === '42P01') {
           this.deps.log.db!(`Table '${schema.table}' does not exist yet. Skipping load for '${modelName}'.`);
           continue;
         }
@@ -278,7 +279,7 @@ export default class PostgresDB {
           this.deps.createRecord(viewName, rawData, { isDbRecord: true, serialize: false, transform: false });
         }
       } catch (error) {
-        if ((error as { code?: string }).code === '42P01') {
+        if (isDbError(error) && error.code === '42P01') {
           this.deps.log.db!(`View '${viewSchema.viewName}' does not exist yet. Skipping load for '${viewName}'.`);
           continue;
         }
@@ -335,7 +336,7 @@ export default class PostgresDB {
 
       return record;
     } catch (error) {
-      if ((error as { code?: string }).code === '42P01') return undefined;
+      if (isDbError(error) && error.code === '42P01') return undefined;
       throw error;
     }
   }
@@ -382,7 +383,7 @@ export default class PostgresDB {
 
       return records;
     } catch (error) {
-      if ((error as { code?: string }).code === '42P01') return [];
+      if (isDbError(error) && error.code === '42P01') return [];
       throw error;
     }
   }
@@ -409,7 +410,7 @@ export default class PostgresDB {
         return { record, distance };
       });
     } catch (error) {
-      if ((error as { code?: string }).code === '42P01') return [];
+      if (isDbError(error) && error.code === '42P01') return [];
       throw error;
     }
   }
@@ -436,7 +437,7 @@ export default class PostgresDB {
         return { record, distance };
       });
     } catch (error) {
-      if ((error as { code?: string }).code === '42P01') return [];
+      if (isDbError(error) && error.code === '42P01') return [];
       throw error;
     }
   }

--- a/src/setup-rest-server.ts
+++ b/src/setup-rest-server.ts
@@ -37,7 +37,7 @@ export default async function(route: string, accessPath: string, metaRoute: bool
       }
     });
   } catch (error) {
-    log.error!((error as Error).message);
+    log.error!(error instanceof Error ? error.message : String(error));
     log.warn!('You must define a valid access configuration file in order to access ORM generated REST endpoints.');
   }
 

--- a/src/timescale/timescale-db.ts
+++ b/src/timescale/timescale-db.ts
@@ -1,4 +1,5 @@
 import PostgresDB from '../postgres/postgres-db.js';
+import { isDbError } from '../utils.js';
 import { buildCreateHypertable, buildTimeBucket, buildContinuousAggregate, buildCompressionPolicy, buildEnableCompression } from './query-builder.js';
 
 interface HypertableOptions {
@@ -63,7 +64,7 @@ export default class TimescaleDB extends PostgresDB {
       const result = await this.pool!.query(sql, values);
       return result.rows;
     } catch (error) {
-      if ((error as { code?: string }).code === '42P01') return [];
+      if (isDbError(error) && error.code === '42P01') return [];
       throw error;
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,9 @@
 import { pluralize as basePluralize } from '@stonyx/utils/string';
 
+export function isDbError(error: unknown): error is { code: string; message: string } {
+  return typeof error === 'object' && error !== null && 'code' in error && typeof (error as Record<string, unknown>).code === 'string' && 'message' in error && typeof (error as Record<string, unknown>).message === 'string';
+}
+
 // Wrapper to handle dasherized model names (e.g., "access-link" → "access-links")
 export function pluralize(word: string): string {
   if (word.includes('-')) {


### PR DESCRIPTION
## Summary
- Adds `isDbError()` type guard in `src/utils.ts` for safe narrowing of database errors with `code` and `message` properties
- Replaces all `(error as { code?: string }).code` patterns across mysql-db, postgres-db, and timescale-db with `isDbError(error) && error.code`
- Replaces all `(error as Error).message` / `(err as Error).message` patterns across cli, migration generators, setup-rest-server, and meta-request with `error instanceof Error ? error.message : String(error)`

## Test plan
- [x] `npx tsc --noEmit` exits 0
- [x] `npm run build` exits 0
- [x] `grep -rn "error as {|error as Error|err as Error" src/` returns 0 matches

Closes #59