### PR TITLE
refactor: add access modifiers and readonly to class members (#56)

### DIFF
--- a/src/aggregates.ts
+++ b/src/aggregates.ts
@@ -6,11 +6,11 @@ interface AggregateRecord {
 }
 
 export class AggregateProperty {
-  aggregateType: AggregateType;
-  relationship: string | undefined;
-  field: string | undefined;
-  mysqlFunction: string;
-  resultType: 'float' | 'number';
+  readonly aggregateType: AggregateType;
+  readonly relationship: string | undefined;
+  readonly field: string | undefined;
+  readonly mysqlFunction: string;
+  readonly resultType: 'float' | 'number';
 
   constructor(aggregateType: AggregateType, relationship?: string, field?: string) {
     this.aggregateType = aggregateType;

--- a/src/model-property.ts
+++ b/src/model-property.ts
@@ -6,7 +6,7 @@ function validType(type: string): boolean {
 
 export default class ModelProperty {
   type: string;
-  _value: unknown;
+  private _value: unknown;
   ignoreFirstTransform?: boolean;
 
   constructor(type: string = 'passthrough', defaultValue?: unknown) {

--- a/src/mysql/mysql-db.ts
+++ b/src/mysql/mysql-db.ts
@@ -346,7 +346,7 @@ export default class MysqlDB {
     }
   }
 
-  _rowToRawData(row: Record<string, unknown>, schema: { columns: Record<string, string>; foreignKeys: Record<string, unknown> }): Record<string, unknown> {
+  private _rowToRawData(row: Record<string, unknown>, schema: { columns: Record<string, string>; foreignKeys: Record<string, unknown> }): Record<string, unknown> {
     const rawData: Record<string, unknown> = { ...row };
 
     for (const [col, mysqlType] of Object.entries(schema.columns)) {
@@ -494,7 +494,7 @@ export default class MysqlDB {
     await this.pool!.execute(sql, values);
   }
 
-  _recordToRow(record: OrmRecord, schema: ModelSchema): Record<string, unknown> {
+  private _recordToRow(record: OrmRecord, schema: ModelSchema): Record<string, unknown> {
     const row: Record<string, unknown> = {};
     const data = record.__data;
 

--- a/src/orm-request.ts
+++ b/src/orm-request.ts
@@ -422,7 +422,7 @@ export default class OrmRequest extends Request {
   }
 
   // Wraps a handler with before/after hook execution
-  _withHooks(operation: string, handler: HandlerFn): HandlerFn {
+  private _withHooks(operation: string, handler: HandlerFn): HandlerFn {
     return async (request: OrmRequest$, state: { [key: string]: unknown }) => {
       // Build context object for hooks
       const context: HookContext = {
@@ -497,7 +497,7 @@ export default class OrmRequest extends Request {
     };
   }
 
-  _generateRelationshipRoutes(
+  private _generateRelationshipRoutes(
     model: string,
     pluralizedModel: string,
     modelRelationships: { [key: string]: RelationshipInfo }

--- a/src/postgres/postgres-db.ts
+++ b/src/postgres/postgres-db.ts
@@ -446,7 +446,7 @@ export default class PostgresDB {
    * The record object itself survives -- the caller retains the reference.
    * @private
    */
-  _evictIfNotMemory(modelName: string, record: OrmRecord): void {
+  private _evictIfNotMemory(modelName: string, record: OrmRecord): void {
     const storeRef = this.deps.store as unknown as {
       _memoryResolver?: (name: string) => boolean;
       get?: (name: string) => Map<unknown, unknown> | undefined;
@@ -459,7 +459,7 @@ export default class PostgresDB {
     }
   }
 
-  _rowToRawData(row: Record<string, unknown>, schema: ModelSchema): Record<string, unknown> {
+  private _rowToRawData(row: Record<string, unknown>, schema: ModelSchema): Record<string, unknown> {
     const rawData: Record<string, unknown> = { ...row };
 
     // PostgreSQL returns native booleans and parsed JSONB -- no manual conversion needed.
@@ -497,7 +497,7 @@ export default class PostgresDB {
     }
   }
 
-  async _persistCreate(modelName: string, _context: PersistContext, response: PersistResponse): Promise<void> {
+  private async _persistCreate(modelName: string, _context: PersistContext, response: PersistResponse): Promise<void> {
     const schemas = this.deps.introspectModels();
     const schema = schemas[modelName];
 
@@ -544,7 +544,7 @@ export default class PostgresDB {
     }
   }
 
-  async _persistUpdate(modelName: string, context: PersistContext, _response: PersistResponse): Promise<void> {
+  private async _persistUpdate(modelName: string, context: PersistContext, _response: PersistResponse): Promise<void> {
     const schemas = this.deps.introspectModels();
     const schema = schemas[modelName];
 
@@ -586,7 +586,7 @@ export default class PostgresDB {
     await this.pool!.query(sql, values);
   }
 
-  async _persistDelete(modelName: string, context: PersistContext): Promise<void> {
+  private async _persistDelete(modelName: string, context: PersistContext): Promise<void> {
     const schemas = this.deps.introspectModels();
     const schema = schemas[modelName];
 
@@ -599,7 +599,7 @@ export default class PostgresDB {
     await this.pool!.query(sql, values);
   }
 
-  _recordToRow(record: OrmRecord, schema: ModelSchema): Record<string, unknown> {
+  private _recordToRow(record: OrmRecord, schema: ModelSchema): Record<string, unknown> {
     const row: Record<string, unknown> = {};
     const data = record.__data;
 

--- a/src/standalone-db.ts
+++ b/src/standalone-db.ts
@@ -21,9 +21,9 @@ interface DBRecord {
 }
 
 export default class StandaloneDB {
-  mode: 'file' | 'directory';
-  dbPath: string;
-  directory: string;
+  readonly mode: 'file' | 'directory';
+  readonly dbPath: string;
+  readonly directory: string;
 
   constructor(options: StandaloneDBOptions = {}) {
     this.mode = options.mode || 'directory';
@@ -174,12 +174,12 @@ export default class StandaloneDB {
 
   // -- Private helpers --
 
-  async _readJSON(filePath: string): Promise<unknown> {
+  private async _readJSON(filePath: string): Promise<unknown> {
     const content = await fs.readFile(filePath, 'utf-8');
     return JSON.parse(content);
   }
 
-  async _writeJSON(filePath: string, data: unknown): Promise<void> {
+  private async _writeJSON(filePath: string, data: unknown): Promise<void> {
     await fs.writeFile(filePath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -155,7 +155,7 @@ export default class Store {
    * Check if a model is configured for in-memory storage.
    * @private
    */
-  _isMemoryModel(modelName: string): boolean {
+  private _isMemoryModel(modelName: string): boolean {
     if (this._memoryResolver) return this._memoryResolver(modelName);
     return false; // default to non-memory if resolver not set yet
   }
@@ -225,7 +225,7 @@ export default class Store {
     for (const relationshipType of TYPES) (relationships.get(relationshipType) as Map<string, unknown>).delete(model);
   }
 
-  _removeFromHasManyArrays(modelName: string, recordId: unknown, visited: Set<string>): void {
+  private _removeFromHasManyArrays(modelName: string, recordId: unknown, visited: Set<string>): void {
     const hasManyRegistry = relationships.get('hasMany') as Map<string, Map<string, Map<unknown, StoreRecord[]>>>;
 
     for (const [sourceModel, targetModels] of hasManyRegistry) {
@@ -244,7 +244,7 @@ export default class Store {
     }
   }
 
-  _nullifyBelongsToReferences(modelName: string, recordId: unknown, visited: Set<string>): void {
+  private _nullifyBelongsToReferences(modelName: string, recordId: unknown, visited: Set<string>): void {
     const belongsToRegistry = relationships.get('belongsTo') as Map<string, Map<string, Map<unknown, StoreRecord | null>>>;
 
     for (const [sourceModel, targetModels] of belongsToRegistry) {
@@ -271,7 +271,7 @@ export default class Store {
     }
   }
 
-  _cleanupRelationshipRegistries(modelName: string, recordId: unknown): void {
+  private _cleanupRelationshipRegistries(modelName: string, recordId: unknown): void {
     const hasManyMap = (relationships.get('hasMany') as Map<string, Map<string, Map<unknown, unknown>>>).get(modelName);
     if (hasManyMap) {
       for (const [, recordMap] of hasManyMap) recordMap.delete(recordId);
@@ -290,7 +290,7 @@ export default class Store {
    * Extracts hasMany and non-bidirectional belongsTo children from a record
    * @private
    */
-  _getChildren(record: StoreRecord): ChildInfo[] {
+  private _getChildren(record: StoreRecord): ChildInfo[] {
     const children: ChildInfo[] = [];
 
     if (!record.__relationships) return children;
@@ -312,14 +312,14 @@ export default class Store {
     return children;
   }
 
-  _isBidirectionalRelationship(sourceModel: string, targetModel: string): boolean {
+  private _isBidirectionalRelationship(sourceModel: string, targetModel: string): boolean {
     const hasManyRegistry = relationships.get('hasMany') as Map<string, Map<string, Map<unknown, unknown>>>;
     const inverseMap = hasManyRegistry.get(targetModel)?.get(sourceModel);
 
     return !!inverseMap && inverseMap.size > 0;
   }
 
-  _buildUnloadQueue(record: StoreRecord, options: UnloadOptions): { toUnload: UnloadQueueItem[]; visited: Set<string> } {
+  private _buildUnloadQueue(record: StoreRecord, options: UnloadOptions): { toUnload: UnloadQueueItem[]; visited: Set<string> } {
     const visited = new Set<string>();
     const toUnload: UnloadQueueItem[] = [];
     const queue: UnloadQueueItem[] = [{

--- a/src/view-resolver.ts
+++ b/src/view-resolver.ts
@@ -66,7 +66,7 @@ export default class ViewResolver {
     return this._resolvePerRecord(sourceRecords, aggregateFields, regularFields, resolveMap, viewClass);
   }
 
-  _resolvePerRecord(
+  private _resolvePerRecord(
     sourceRecords: SourceRecord[],
     aggregateFields: Record<string, AggregateProperty>,
     regularFields: Record<string, unknown>,
@@ -128,7 +128,7 @@ export default class ViewResolver {
     return results;
   }
 
-  _resolveGroupBy(
+  private _resolveGroupBy(
     sourceRecords: SourceRecord[],
     groupByField: string,
     aggregateFields: Record<string, AggregateProperty>,


### PR DESCRIPTION
## Summary
- Added `private` to all `_`-prefixed methods across `store.ts`, `mysql-db.ts`, `postgres-db.ts`, `orm-request.ts`, `view-resolver.ts`, `standalone-db.ts`, and `model-property.ts`
- Added `readonly` to constructor-only properties in `aggregates.ts` (`aggregateType`, `relationship`, `field`, `mysqlFunction`, `resultType`) and `standalone-db.ts` (`mode`, `dbPath`, `directory`)
- Left `_memoryResolver` and `_sqlDb` on Store public (assigned externally from `main.ts`)
- Left Record's `__data`, `__relationships`, etc. as-is (incompatible with index signature)

## Test plan
- [x] `npx tsc --noEmit` exits 0
- [x] `npm run build` exits 0

Closes #56