### PR TITLE
refactor: replace runtime introspection with instanceof and discriminants (#53)

### DIFF
--- a/src/belongs-to.ts
+++ b/src/belongs-to.ts
@@ -22,6 +22,7 @@ interface PendingBelongsToEntry {
 
 type RelationshipHandler = ((sourceRecord: SourceRecord, rawData: unknown, options: BelongsToOptions) => unknown) & {
   __relatedModelName: string;
+  __relationshipType: 'belongsTo';
 };
 
 export default function belongsTo(modelName: string): RelationshipHandler {
@@ -84,5 +85,6 @@ export default function belongsTo(modelName: string): RelationshipHandler {
   };
 
   Object.defineProperty(fn, '__relatedModelName', { value: modelName });
+  Object.defineProperty(fn, '__relationshipType', { value: 'belongsTo' as const });
   return fn as RelationshipHandler;
 }

--- a/src/has-many.ts
+++ b/src/has-many.ts
@@ -17,6 +17,7 @@ interface PendingItem {
 
 type RelationshipHandler = ((sourceRecord: SourceRecord, rawData: unknown, options: HasManyOptions) => unknown[]) & {
   __relatedModelName: string;
+  __relationshipType: 'hasMany';
 };
 
 function queuePendingRelationship(
@@ -86,5 +87,6 @@ export default function hasMany(modelName: string): RelationshipHandler {
   };
 
   Object.defineProperty(fn, '__relatedModelName', { value: modelName });
+  Object.defineProperty(fn, '__relationshipType', { value: 'hasMany' as const });
   return fn as RelationshipHandler;
 }

--- a/src/meta-request.ts
+++ b/src/meta-request.ts
@@ -1,4 +1,5 @@
 import { Request } from '@stonyx/rest-server';
+import ModelProperty from './model-property.js';
 import Orm from './main.js';
 import config from 'stonyx/config';
 import { dbKey } from './db.js';
@@ -29,11 +30,11 @@ export default class MetaRequest extends Request {
                 // Skip internal properties
                 if (key.startsWith('__')) continue;
 
-                if ((property as { constructor?: { name?: string } })?.constructor?.name === 'ModelProperty') {
+                if (property instanceof ModelProperty) {
                   properties[key] = { type: (property as { type: string }).type };
                 } else if (typeof property === 'function') {
-                  const isBelongsTo = property.toString().includes(`getRelationships('belongsTo',`);
-                  const isHasMany = property.toString().includes(`getRelationships('hasMany',`);
+                  const isBelongsTo = (property as { __relationshipType?: string }).__relationshipType === 'belongsTo';
+                  const isHasMany = (property as { __relationshipType?: string }).__relationshipType === 'hasMany';
 
                   if (isBelongsTo || isHasMany) properties[key] = { [isBelongsTo ? 'belongsTo' : 'hasMany']: name };
                 }

--- a/src/mysql/schema-introspector.ts
+++ b/src/mysql/schema-introspector.ts
@@ -5,6 +5,7 @@ import { getPluralName } from '../plural-registry.js';
 import { dbKey } from '../db.js';
 import { AggregateProperty } from '../aggregates.js';
 import type { ForeignKeyDef, ModelSchema, ViewSchema, SnapshotEntry } from '../types/orm-types.js';
+import ModelProperty from '../model-property.js';
 
 interface RelationshipInfo {
   type: 'belongsTo' | 'hasMany';
@@ -16,23 +17,18 @@ interface JoinClause {
   condition: string;
 }
 
-interface ModelProperty {
-  type: string;
-  constructor: { name: string };
-}
-
 interface RelationshipProperty {
   __relatedModelName?: string | null;
-  toString(): string;
+  __relationshipType?: string;
 }
 
 function getRelationshipInfo(property: unknown): RelationshipInfo | null {
   if (typeof property !== 'function') return null;
-  const fnStr = (property as RelationshipProperty).toString();
+  const relType = (property as RelationshipProperty).__relationshipType;
   const modelName = (property as RelationshipProperty).__relatedModelName || null;
 
-  if (fnStr.includes(`getRelationships('belongsTo',`)) return { type: 'belongsTo', modelName };
-  if (fnStr.includes(`getRelationships('hasMany',`)) return { type: 'hasMany', modelName };
+  if (relType === 'belongsTo') return { type: 'belongsTo', modelName };
+  if (relType === 'hasMany') return { type: 'hasMany', modelName };
 
   return null;
 }
@@ -67,7 +63,7 @@ export function introspectModels(): Record<string, ModelSchema> {
         relationships.belongsTo[key] = relInfo.modelName;
       } else if (relInfo?.type === 'hasMany') {
         relationships.hasMany[key] = relInfo.modelName;
-      } else if ((property as ModelProperty)?.constructor?.name === 'ModelProperty') {
+      } else if (property instanceof ModelProperty) {
         if (key === 'id') {
           idType = (property as ModelProperty).type;
         } else {
@@ -210,7 +206,7 @@ export function introspectViews(): Record<string, ViewSchema> {
         };
       } else if (relInfo?.type === 'hasMany') {
         relationships.hasMany[key] = relInfo.modelName;
-      } else if ((property as ModelProperty)?.constructor?.name === 'ModelProperty') {
+      } else if (property instanceof ModelProperty) {
         const transforms = orm.transforms;
         columns[key] = getMysqlType((property as ModelProperty).type, transforms[(property as ModelProperty).type] as ((...args: unknown[]) => unknown) & { mysqlType?: string });
       }

--- a/src/orm-request.ts
+++ b/src/orm-request.ts
@@ -63,11 +63,11 @@ const WRITE_OPERATIONS = new Set(['create', 'update', 'delete']);
 // Helper to detect relationship type from function
 function getRelationshipInfo(property: unknown): RelationshipInfo | null {
   if (typeof property !== 'function') return null;
-  const fnStr = property.toString();
-  if (fnStr.includes(`getRelationships('belongsTo',`)) {
+  const relType = (property as { __relationshipType?: string }).__relationshipType;
+  if (relType === 'belongsTo') {
     return { type: 'belongsTo', isArray: false };
   }
-  if (fnStr.includes(`getRelationships('hasMany',`)) {
+  if (relType === 'hasMany') {
     return { type: 'hasMany', isArray: true };
   }
   return null;

--- a/src/postgres/schema-introspector.ts
+++ b/src/postgres/schema-introspector.ts
@@ -5,6 +5,7 @@ import { getPluralName } from '../plural-registry.js';
 import { dbKey } from '../db.js';
 import { AggregateProperty } from '../aggregates.js';
 import type { ForeignKeyDef, ModelSchema, ViewSchema } from '../types/orm-types.js';
+import ModelProperty from '../model-property.js';
 
 interface RelationshipInfo {
   type: 'belongsTo' | 'hasMany';
@@ -36,11 +37,11 @@ interface JoinDef {
 
 function getRelationshipInfo(property: unknown): RelationshipInfo | null {
   if (typeof property !== 'function') return null;
-  const fnStr = property.toString();
+  const relType = (property as { __relationshipType?: string }).__relationshipType;
   const modelName = (property as { __relatedModelName?: string }).__relatedModelName || null;
 
-  if (fnStr.includes(`getRelationships('belongsTo',`)) return { type: 'belongsTo', modelName };
-  if (fnStr.includes(`getRelationships('hasMany',`)) return { type: 'hasMany', modelName };
+  if (relType === 'belongsTo') return { type: 'belongsTo', modelName };
+  if (relType === 'hasMany') return { type: 'hasMany', modelName };
 
   return null;
 }
@@ -76,7 +77,7 @@ export function introspectModels(): Record<string, ModelSchema> {
         relationships.belongsTo[key] = relInfo.modelName;
       } else if (relInfo?.type === 'hasMany') {
         relationships.hasMany[key] = relInfo.modelName;
-      } else if ((property as { constructor?: { name?: string } })?.constructor?.name === 'ModelProperty') {
+      } else if (property instanceof ModelProperty) {
         const prop = property as { type: string; dimensions?: number };
         if (key === 'id') {
           idType = prop.type;
@@ -239,7 +240,7 @@ export function introspectViews(): Record<string, ViewSchema> {
         };
       } else if (relInfo?.type === 'hasMany') {
         relationships.hasMany[key] = relInfo.modelName;
-      } else if ((property as { constructor?: { name?: string } })?.constructor?.name === 'ModelProperty') {
+      } else if (property instanceof ModelProperty) {
         const transforms = (Orm.instance as { transforms: Record<string, unknown> }).transforms;
         const prop = property as { type: string };
         columns[key] = getPgType(prop.type, transforms[prop.type] as undefined);

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,5 +1,7 @@
 import config from 'stonyx/config';
 import { get, makeArray } from '@stonyx/utils/object';
+import { AggregateProperty } from './aggregates.js';
+import ModelProperty from './model-property.js';
 
 const RESERVED_KEYS = ['__name'];
 
@@ -91,14 +93,14 @@ export default class Serializer {
       }
 
       // Aggregate property handling — use the rawData value, not the aggregate descriptor
-      if ((handler as { constructor?: { name?: string } })?.constructor?.name === 'AggregateProperty') {
+      if (handler instanceof AggregateProperty) {
         parsedData[key] = data;
         rec[key] = data;
         continue;
       }
 
       // Direct assignment handling
-      if ((handler as { constructor?: { name?: string } })?.constructor?.name !== 'ModelProperty') {
+      if (!(handler instanceof ModelProperty)) {
         parsedData[key] = handler;
         rec[key] = handler;
         continue;


### PR DESCRIPTION
## Summary

- Adds `__relationshipType` discriminant property (`'belongsTo'` / `'hasMany'`) to relationship handler functions in `belongs-to.ts` and `has-many.ts`
- Replaces all `constructor.name === 'AggregateProperty'` and `constructor.name === 'ModelProperty'` checks with `instanceof` in serializer, mysql/schema-introspector, and postgres/schema-introspector
- Replaces all `toString().includes("getRelationships('belongsTo',")` / `toString().includes("getRelationships('hasMany',")` with `__relationshipType` property checks in orm-request, meta-request, and both schema introspectors

Closes #53

## Test plan

- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm run build` passes
- [x] `grep -r "constructor\.name" src/` returns 0 matches
- [x] `grep -r "toString().includes" src/` returns 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)