### PR TITLE
refactor: type config as OrmConfig to eliminate unsafe casts (#52)

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -43,8 +43,8 @@ const commands: Record<string, Command> = {
     description: 'Apply pending MySQL migrations',
     bootstrap: true,
     run: async () => {
-      const config = (await import('stonyx/config')).default as Record<string, unknown>;
-      const mysqlConfig = (config.orm as Record<string, unknown>)?.mysql as Record<string, unknown> | undefined;
+      const config = (await import('stonyx/config')).default;
+      const mysqlConfig = config.orm.mysql;
 
       if (!mysqlConfig) {
         console.error('MySQL is not configured. Set MYSQL_HOST to enable MySQL mode.');
@@ -56,8 +56,8 @@ const commands: Record<string, Command> = {
       const { readFile } = await import('@stonyx/utils/file');
       const path = await import('path');
 
-      const pool = await getPool(mysqlConfig as unknown as MysqlConfig);
-      const migrationsPath = path.resolve(config.rootPath as string, mysqlConfig.migrationsDir as string);
+      const pool = await getPool(mysqlConfig as MysqlConfig);
+      const migrationsPath = path.resolve(config.rootPath, mysqlConfig.migrationsDir as string);
 
       try {
         await ensureMigrationsTable(pool, mysqlConfig.migrationsTable as string);
@@ -91,8 +91,8 @@ const commands: Record<string, Command> = {
     description: 'Rollback the most recent MySQL migration',
     bootstrap: true,
     run: async () => {
-      const config = (await import('stonyx/config')).default as Record<string, unknown>;
-      const mysqlConfig = (config.orm as Record<string, unknown>)?.mysql as Record<string, unknown> | undefined;
+      const config = (await import('stonyx/config')).default;
+      const mysqlConfig = config.orm.mysql;
 
       if (!mysqlConfig) {
         console.error('MySQL is not configured. Set MYSQL_HOST to enable MySQL mode.');
@@ -104,8 +104,8 @@ const commands: Record<string, Command> = {
       const { readFile } = await import('@stonyx/utils/file');
       const path = await import('path');
 
-      const pool = await getPool(mysqlConfig as unknown as MysqlConfig);
-      const migrationsPath = path.resolve(config.rootPath as string, mysqlConfig.migrationsDir as string);
+      const pool = await getPool(mysqlConfig as MysqlConfig);
+      const migrationsPath = path.resolve(config.rootPath, mysqlConfig.migrationsDir as string);
 
       try {
         await ensureMigrationsTable(pool, mysqlConfig.migrationsTable as string);
@@ -137,8 +137,8 @@ const commands: Record<string, Command> = {
     description: 'Show status of MySQL migrations',
     bootstrap: true,
     run: async () => {
-      const config = (await import('stonyx/config')).default as Record<string, unknown>;
-      const mysqlConfig = (config.orm as Record<string, unknown>)?.mysql as Record<string, unknown> | undefined;
+      const config = (await import('stonyx/config')).default;
+      const mysqlConfig = config.orm.mysql;
 
       if (!mysqlConfig) {
         console.error('MySQL is not configured. Set MYSQL_HOST to enable MySQL mode.');
@@ -149,8 +149,8 @@ const commands: Record<string, Command> = {
       const { ensureMigrationsTable, getAppliedMigrations, getMigrationFiles } = await import('./mysql/migration-runner.js');
       const path = await import('path');
 
-      const pool = await getPool(mysqlConfig as unknown as MysqlConfig);
-      const migrationsPath = path.resolve(config.rootPath as string, mysqlConfig.migrationsDir as string);
+      const pool = await getPool(mysqlConfig as MysqlConfig);
+      const migrationsPath = path.resolve(config.rootPath, mysqlConfig.migrationsDir as string);
 
       try {
         await ensureMigrationsTable(pool, mysqlConfig.migrationsTable as string);

--- a/src/db.ts
+++ b/src/db.ts
@@ -24,20 +24,6 @@ import path from 'path';
 
 export const dbKey = '__db';
 
-interface DBConfig {
-  rootPath: string;
-  orm: {
-    db: {
-      file: string;
-      schema: string;
-      mode: string;
-      directory: string;
-      autosave: string;
-      saveInterval: unknown;
-    };
-  };
-}
-
 interface DBRecord {
   format(): Record<string, unknown>;
   [key: string]: unknown;
@@ -54,8 +40,8 @@ export default class DB {
   }
 
   async getSchema(): Promise<unknown> {
-    const { rootPath } = config as unknown as DBConfig;
-    const { file, schema } = (config as unknown as DBConfig).orm.db;
+    const { rootPath } = config;
+    const { file, schema } = config.orm.db;
 
     if (!file) throw new Error('Configuration Error: ORM DB file path must be defined.');
 
@@ -76,16 +62,16 @@ export default class DB {
   }
 
   getDirPath(): string {
-    const { rootPath } = config as unknown as DBConfig;
-    const { file, directory } = (config as unknown as DBConfig).orm.db;
+    const { rootPath } = config;
+    const { file, directory } = config.orm.db;
     const dbDir = path.dirname(path.resolve(`${rootPath}/${file}`));
 
     return path.join(dbDir, directory);
   }
 
   async validateMode(): Promise<void> {
-    const { rootPath } = config as unknown as DBConfig;
-    const { file, mode } = (config as unknown as DBConfig).orm.db;
+    const { rootPath } = config;
+    const { file, mode } = config.orm.db;
     const collectionKeys = this.getCollectionKeys();
     const dirPath = this.getDirPath();
 
@@ -111,7 +97,7 @@ export default class DB {
         )).some(Boolean);
 
         if (hasCollectionFiles) {
-          log.error!(`DB mode mismatch: directory '${(config as unknown as DBConfig).orm.db.directory}/' contains collection files but mode is set to 'file'. Run migration first:\n\n  stonyx db:migrate-to-file\n`);
+          log.error!(`DB mode mismatch: directory '${config.orm.db.directory}/' contains collection files but mode is set to 'file'. Run migration first:\n\n  stonyx db:migrate-to-file\n`);
           process.exit(1);
         }
       }
@@ -119,7 +105,7 @@ export default class DB {
   }
 
   async init(): Promise<void> {
-    const { autosave, saveInterval } = (config as unknown as DBConfig).orm.db;
+    const { autosave, saveInterval } = config.orm.db;
 
     store.set(dbKey, new Map());
     (Orm.instance as Orm).models[`${dbKey}Model`] = await this.getSchema();
@@ -133,8 +119,8 @@ export default class DB {
   }
 
   async create(): Promise<Record<string, unknown>> {
-    const { rootPath } = config as unknown as DBConfig;
-    const { file, mode } = (config as unknown as DBConfig).orm.db;
+    const { rootPath } = config;
+    const { file, mode } = config.orm.db;
 
     if (mode === 'directory') {
       const dirPath = this.getDirPath();
@@ -161,7 +147,7 @@ export default class DB {
   }
 
   async save(): Promise<void> {
-    const { file, mode } = (config as unknown as DBConfig).orm.db;
+    const { file, mode } = config.orm.db;
     const jsonData = this.record.format() as Record<string, unknown>;
     delete jsonData.id; // Don't save id
 
@@ -184,23 +170,23 @@ export default class DB {
       const skeleton: Record<string, unknown[]> = {};
       for (const key of collectionKeys) skeleton[key] = [];
 
-      const dbFilePath = `${(config as unknown as DBConfig).rootPath}/${file}`;
+      const dbFilePath = `${config.rootPath}/${file}`;
       const dbFileExists = await fileExists(dbFilePath);
 
       if (dbFileExists) await updateFile(dbFilePath, skeleton, { json: true });
       else await createFile(dbFilePath, skeleton, { json: true });
 
-      log.db!(`DB has been successfully saved to ${(config as unknown as DBConfig).orm.db.directory}/ directory`);
+      log.db!(`DB has been successfully saved to ${config.orm.db.directory}/ directory`);
       return;
     }
 
-    await updateFile(`${(config as unknown as DBConfig).rootPath}/${file}`, jsonData, { json: true });
+    await updateFile(`${config.rootPath}/${file}`, jsonData, { json: true });
 
     log.db!(`DB has been successfully saved to ${file}`);
   }
 
   async getRecord(): Promise<DBRecord> {
-    const { mode } = (config as unknown as DBConfig).orm.db;
+    const { mode } = config.orm.db;
 
     if (mode === 'directory') return this.getRecordFromDirectory();
 
@@ -208,7 +194,7 @@ export default class DB {
   }
 
   async getRecordFromFile(): Promise<DBRecord> {
-    const { file } = (config as unknown as DBConfig).orm.db;
+    const { file } = config.orm.db;
 
     const data = await readFile(file, { json: true, missingFileCallback: this.create.bind(this) });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,10 +81,7 @@ export default class Orm {
   }
 
   async init(): Promise<void> {
-    const { paths, restServer } = config.orm as {
-      paths: Record<string, string>;
-      restServer: { enabled: string; route: string; metaRoute: boolean };
-    };
+    const { paths, restServer } = config.orm;
 
     const promises: Promise<unknown>[] = ['Model', 'Serializer', 'Transform'].map(type => {
       const lowerCaseType = type.toLowerCase();
@@ -137,17 +134,17 @@ export default class Orm {
 
     setup(eventNames);
 
-    if ((config.orm as Record<string, unknown>).timescale) {
+    if (config.orm.timescale) {
       const { default: TimescaleDB } = await import('./timescale/timescale-db.js');
       this.sqlDb = new TimescaleDB() as SqlDb;
       this.db = this.sqlDb;
       promises.push(this.sqlDb.init());
-    } else if ((config.orm as Record<string, unknown>).postgres) {
+    } else if (config.orm.postgres) {
       const { default: PostgresDB } = await import('./postgres/postgres-db.js');
       this.sqlDb = new PostgresDB() as SqlDb;
       this.db = this.sqlDb;
       promises.push(this.sqlDb.init());
-    } else if ((config.orm as Record<string, unknown>).mysql) {
+    } else if (config.orm.mysql) {
       const { default: MysqlDB } = await import('./mysql/mysql-db.js');
       this.sqlDb = new MysqlDB() as SqlDb;
       this.db = this.sqlDb;

--- a/src/meta-request.ts
+++ b/src/meta-request.ts
@@ -53,6 +53,6 @@ export default class MetaRequest extends Request {
   }
 
   auth(): number | undefined {
-    if (!(config as Record<string, unknown> & { orm: { restServer: { metaRoute: unknown } } }).orm.restServer.metaRoute) return 403;
+    if (!config.orm.restServer.metaRoute) return 403;
   }
 }

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -18,16 +18,16 @@ function getCollectionKeys(): string[] {
 }
 
 function getDirPath(): string {
-  const { rootPath } = config as { rootPath: string; orm: { db: { file: string; directory: string } } };
-  const { file, directory } = (config as { orm: { db: { file: string; directory: string } } }).orm.db;
+  const { rootPath } = config;
+  const { file, directory } = config.orm.db;
   const dbDir = path.dirname(path.resolve(`${rootPath}/${file}`));
 
   return path.join(dbDir, directory);
 }
 
 export async function fileToDirectory(): Promise<void> {
-  const { rootPath } = config as { rootPath: string };
-  const { file } = (config as { orm: { db: { file: string } } }).orm.db;
+  const { rootPath } = config;
+  const { file } = config.orm.db;
   const dbFilePath = path.resolve(`${rootPath}/${file}`);
   const collectionKeys = getCollectionKeys();
   const dirPath = getDirPath();
@@ -50,8 +50,8 @@ export async function fileToDirectory(): Promise<void> {
 }
 
 export async function directoryToFile(): Promise<void> {
-  const { rootPath } = config as { rootPath: string };
-  const { file } = (config as { orm: { db: { file: string } } }).orm.db;
+  const { rootPath } = config;
+  const { file } = config.orm.db;
   const dbFilePath = path.resolve(`${rootPath}/${file}`);
   const collectionKeys = getCollectionKeys();
   const dirPath = getDirPath();

--- a/src/mysql/migration-generator.ts
+++ b/src/mysql/migration-generator.ts
@@ -51,9 +51,9 @@ interface GeneratedMigration {
 type Snapshot = Record<string, SnapshotEntry & { isView?: boolean; viewName?: string; viewQuery?: string; source?: string }>;
 
 export async function generateMigration(description: string = 'migration'): Promise<GeneratedMigration | null> {
-  const { migrationsDir } = (config as Record<string, unknown> & { orm: { mysql: { migrationsDir: string } } }).orm.mysql;
-  const rootPath = (config as Record<string, unknown> & { rootPath: string }).rootPath;
-  const migrationsPath = path.resolve(rootPath, migrationsDir);
+  const { migrationsDir } = config.orm.mysql!;
+  const rootPath = config.rootPath;
+  const migrationsPath = path.resolve(rootPath, migrationsDir!);
 
   await createDirectory(migrationsPath);
 

--- a/src/mysql/mysql-db.ts
+++ b/src/mysql/mysql-db.ts
@@ -60,7 +60,7 @@ interface MysqlDBDeps {
   confirm: typeof confirm;
   readFile: typeof readFile;
   getPluralName: typeof getPluralName;
-  config: Record<string, unknown> & { orm: { mysql: MysqlConfig }; rootPath: string };
+  config: typeof config;
   log: Record<string, ((...args: unknown[]) => void) | undefined>;
   path: typeof path;
 }
@@ -72,7 +72,7 @@ const defaultDeps: MysqlDBDeps = {
   loadLatestSnapshot, detectSchemaDrift,
   buildInsert, buildUpdate, buildDelete, buildSelect,
   createRecord, store: store as unknown as OrmStore, confirm, readFile, getPluralName,
-  config: config as unknown as MysqlDBDeps['config'], log, path
+  config, log, path
 };
 
 export default class MysqlDB {
@@ -88,7 +88,7 @@ export default class MysqlDB {
 
     this.deps = { ...defaultDeps, ...deps } as MysqlDBDeps;
     this.pool = null;
-    this.mysqlConfig = this.deps.config.orm.mysql;
+    this.mysqlConfig = this.deps.config.orm.mysql!;
   }
 
   private requirePool(): Pool {

--- a/src/orm-request.ts
+++ b/src/orm-request.ts
@@ -481,7 +481,7 @@ export default class OrmRequest extends Request {
       }
 
       // Auto-save DB after write operations when configured
-      if ((config as { orm: { db: { autosave: string } } }).orm.db.autosave === 'onUpdate' && WRITE_OPERATIONS.has(operation)) {
+      if (config.orm.db.autosave === 'onUpdate' && WRITE_OPERATIONS.has(operation)) {
         await (Orm.db as { save(): Promise<void> }).save();
       }
 

--- a/src/postgres/migration-generator.ts
+++ b/src/postgres/migration-generator.ts
@@ -49,8 +49,8 @@ interface MigrationResult {
 }
 
 export async function generateMigration(description: string = 'migration', configKey: string = 'postgres'): Promise<MigrationResult | null> {
-  const { migrationsDir } = (config as Record<string, unknown> & { orm: Record<string, unknown> }).orm[configKey] as { migrationsDir: string };
-  const rootPath = config.rootPath as string;
+  const { migrationsDir } = config.orm[configKey] as { migrationsDir: string };
+  const rootPath = config.rootPath;
   const migrationsPath = path.resolve(rootPath, migrationsDir);
 
   await createDirectory(migrationsPath);

--- a/src/postgres/postgres-db.ts
+++ b/src/postgres/postgres-db.ts
@@ -96,7 +96,7 @@ export default class PostgresDB {
 
     this.deps = { ...defaultDeps, ...deps } as PostgresDeps;
     this.pool = null;
-    this.pgConfig = (this.deps.config as Record<string, Record<string, unknown>>).orm[Ctor.configKey] as Record<string, unknown>;
+    this.pgConfig = this.deps.config.orm[Ctor.configKey] as Record<string, unknown>;
   }
 
   protected requirePool(): Pool {
@@ -114,7 +114,7 @@ export default class PostgresDB {
   }
 
   async startup(): Promise<void> {
-    const migrationsPath = this.deps.path.resolve(this.deps.config.rootPath as string, this.pgConfig.migrationsDir as string);
+    const migrationsPath = this.deps.path.resolve(this.deps.config.rootPath, this.pgConfig.migrationsDir as string);
 
     // Check for pending migrations
     const applied = await this.deps.getAppliedMigrations(this.requirePool(), this.pgConfig.migrationsTable as string | undefined);
@@ -167,7 +167,7 @@ export default class PostgresDB {
 
     // Check for schema drift
     const schemas = this.deps.introspectModels();
-    const snapshot = await this.deps.loadLatestSnapshot(this.deps.path.resolve(this.deps.config.rootPath as string, this.pgConfig.migrationsDir as string));
+    const snapshot = await this.deps.loadLatestSnapshot(this.deps.path.resolve(this.deps.config.rootPath, this.pgConfig.migrationsDir as string));
 
     if (Object.keys(snapshot).length > 0) {
       const drift = this.deps.detectSchemaDrift(schemas, snapshot as Parameters<typeof detectSchemaDrift>[1]);

--- a/src/types/orm-types.ts
+++ b/src/types/orm-types.ts
@@ -1,5 +1,69 @@
 import type { AggregateProperty } from '../aggregates.js';
 
+export interface OrmDbConfig {
+  file: string;
+  schema: string;
+  mode: string;
+  directory: string;
+  autosave: string;
+  saveInterval: unknown;
+}
+
+export interface OrmMysqlConfig {
+  host: string;
+  port?: number;
+  user: string;
+  password: string;
+  database: string;
+  connectionLimit?: number;
+  migrationsDir?: string;
+  migrationsTable?: string;
+  [key: string]: unknown;
+}
+
+export interface OrmPostgresConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+  connectionLimit?: number;
+  migrationsDir?: string;
+  migrationsTable?: string;
+  [key: string]: unknown;
+}
+
+export interface OrmPaths {
+  model: string;
+  serializer: string;
+  transform: string;
+  view?: string;
+  access?: string;
+  [key: string]: string | undefined;
+}
+
+export interface OrmRestServerConfig {
+  enabled: string;
+  route: string;
+  metaRoute: boolean;
+}
+
+export interface OrmSection {
+  db: OrmDbConfig;
+  paths: OrmPaths;
+  restServer: OrmRestServerConfig;
+  mysql?: OrmMysqlConfig;
+  postgres?: OrmPostgresConfig;
+  timescale?: OrmPostgresConfig;
+  [key: string]: unknown;
+}
+
+export interface OrmConfig {
+  rootPath: string;
+  orm: OrmSection;
+  [key: string]: unknown;
+}
+
 export interface SourceRecord {
   __model: { __name: string; [key: string]: unknown };
   __data?: Record<string, unknown>;

--- a/src/types/stonyx.d.ts
+++ b/src/types/stonyx.d.ts
@@ -1,5 +1,6 @@
 declare module 'stonyx/config' {
-  const config: Record<string, unknown>;
+  import type { OrmConfig } from './orm-types.js';
+  const config: OrmConfig;
   export default config;
 }
 


### PR DESCRIPTION
## Summary

- Defines `OrmConfig` interface hierarchy in `src/types/orm-types.ts` (`OrmConfig`, `OrmSection`, `OrmDbConfig`, `OrmMysqlConfig`, `OrmPostgresConfig`, `OrmPaths`, `OrmRestServerConfig`)
- Updates `stonyx/config` module declaration in `src/types/stonyx.d.ts` from `Record<string, unknown>` to `OrmConfig`
- Removes ~30 unsafe `as unknown as DBConfig` / `as Record<string, unknown>` casts across 10 files: `db.ts`, `main.ts`, `migrate.ts`, `commands.ts`, `orm-request.ts`, `meta-request.ts`, `mysql/mysql-db.ts`, `mysql/migration-generator.ts`, `postgres/postgres-db.ts`, `postgres/migration-generator.ts`

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm run build:test && npx qunit 'dist-test/test/**/*-test.js'` — 221 pass / 41 fail (identical to dev baseline)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)