### PR TITLE
fix: resolve dual module graph causing 67 test failures (#69)

### DIFF
--- a/src/aggregates.ts
+++ b/src/aggregates.ts
@@ -6,6 +6,7 @@ interface AggregateRecord {
 }
 
 export class AggregateProperty {
+  readonly __kind = 'AggregateProperty' as const;
   readonly aggregateType: AggregateType;
   readonly relationship: string | undefined;
   readonly field: string | undefined;

--- a/src/belongs-to.ts
+++ b/src/belongs-to.ts
@@ -1,5 +1,4 @@
-import { store } from './main.js';
-import { createRecord } from './manage-record.js';
+import { createRecord, store } from '@stonyx/orm';
 import { getRelationships, getHasManyRegistry, getPendingRegistry, getPendingBelongsToRegistry } from './relationships.js';
 import type { SourceRecord } from './types/orm-types.js';
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -17,7 +17,7 @@
 import Cron from '@stonyx/cron';
 import config from 'stonyx/config';
 import log from 'stonyx/log';
-import Orm, { store } from './main.js';
+import Orm, { store } from '@stonyx/orm';
 import { createRecord } from './manage-record.js';
 import { createFile, createDirectory, updateFile, readFile, fileExists } from '@stonyx/utils/file';
 import path from 'path';

--- a/src/exports/db.ts
+++ b/src/exports/db.ts
@@ -1,4 +1,4 @@
-import Orm from '../main.js';
+import Orm from '@stonyx/orm';
 
 const db = Orm.db as { record: unknown; save(): Promise<void> };
 

--- a/src/has-many.ts
+++ b/src/has-many.ts
@@ -1,5 +1,4 @@
-import { store } from './main.js';
-import { createRecord } from './manage-record.js';
+import { createRecord, store } from '@stonyx/orm';
 import { getRelationships, getGlobalRegistry, getPendingRegistry, getBelongsToRegistry } from './relationships.js';
 import { getOrSet, makeArray } from '@stonyx/utils/object';
 import { dbKey } from './db.js';

--- a/src/manage-record.ts
+++ b/src/manage-record.ts
@@ -1,4 +1,4 @@
-import Orm, { store } from './main.js';
+import Orm, { store } from '@stonyx/orm';
 import OrmRecord from './record.js';
 import { getGlobalRegistry, getPendingRegistry, getPendingBelongsToRegistry, getBelongsToRegistry, getHasManyRegistry } from './relationships.js';
 import type Serializer from './serializer.js';

--- a/src/meta-request.ts
+++ b/src/meta-request.ts
@@ -1,6 +1,6 @@
 import { Request } from '@stonyx/rest-server';
 import ModelProperty from './model-property.js';
-import Orm from './main.js';
+import Orm from '@stonyx/orm';
 import config from 'stonyx/config';
 import { dbKey } from './db.js';
 

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,5 +1,5 @@
 import config from 'stonyx/config';
-import Orm from './main.js';
+import Orm from '@stonyx/orm';
 import { createFile, createDirectory, readFile, updateFile, deleteDirectory } from '@stonyx/utils/file';
 import { dbKey } from './db.js';
 import path from 'path';

--- a/src/model-property.ts
+++ b/src/model-property.ts
@@ -1,10 +1,11 @@
-import Orm from './main.js';
+import Orm from '@stonyx/orm';
 
 function validType(type: string): boolean {
   return Object.keys(Orm.instance.transforms).includes(type);
 }
 
 export default class ModelProperty {
+  readonly __kind = 'ModelProperty' as const;
   type: string;
   private _value: unknown;
   ignoreFirstTransform?: boolean;

--- a/src/mysql/mysql-db.ts
+++ b/src/mysql/mysql-db.ts
@@ -5,7 +5,7 @@ import { introspectModels, introspectViews, getTopologicalOrder, schemasToSnapsh
 import type { ModelSchema, ViewSchema, SnapshotEntry } from './schema-introspector.js';
 import { loadLatestSnapshot, detectSchemaDrift } from './migration-generator.js';
 import { buildInsert, buildUpdate, buildDelete, buildSelect } from './query-builder.js';
-import { store } from '../main.js';
+import { store } from '@stonyx/orm';
 import { createRecord } from '../manage-record.js';
 import { confirm } from '@stonyx/utils/prompt';
 import { readFile } from '@stonyx/utils/file';

--- a/src/mysql/schema-introspector.ts
+++ b/src/mysql/schema-introspector.ts
@@ -1,4 +1,4 @@
-import Orm from '../main.js';
+import Orm from '@stonyx/orm';
 import { getMysqlType } from './type-map.js';
 import { camelCaseToKebabCase } from '@stonyx/utils/string';
 import { getPluralName } from '../plural-registry.js';

--- a/src/orm-request.ts
+++ b/src/orm-request.ts
@@ -1,6 +1,5 @@
 import { Request } from '@stonyx/rest-server';
-import Orm, { store } from './main.js';
-import { createRecord, updateRecord } from './manage-record.js';
+import Orm, { store, createRecord, updateRecord } from '@stonyx/orm';
 import { camelCaseToKebabCase } from '@stonyx/utils/string';
 import { getPluralName } from './plural-registry.js';
 import { getBeforeHooks, getAfterHooks } from './hooks.js';

--- a/src/postgres/postgres-db.ts
+++ b/src/postgres/postgres-db.ts
@@ -3,7 +3,7 @@ import { ensureMigrationsTable, getAppliedMigrations, getMigrationFiles, applyMi
 import { introspectModels, introspectViews, getTopologicalOrder, schemasToSnapshot } from './schema-introspector.js';
 import { loadLatestSnapshot, detectSchemaDrift } from './migration-generator.js';
 import { buildInsert, buildUpdate, buildDelete, buildSelect, buildVectorSearch, buildHybridSearch } from './query-builder.js';
-import { store } from '../main.js';
+import { store } from '@stonyx/orm';
 import { createRecord } from '../manage-record.js';
 import { confirm } from '@stonyx/utils/prompt';
 import { readFile } from '@stonyx/utils/file';

--- a/src/postgres/schema-introspector.ts
+++ b/src/postgres/schema-introspector.ts
@@ -1,4 +1,4 @@
-import Orm from '../main.js';
+import Orm from '@stonyx/orm';
 import { getPgType, getVectorType } from './type-map.js';
 import { camelCaseToKebabCase } from '@stonyx/utils/string';
 import { getPluralName } from '../plural-registry.js';

--- a/src/record.ts
+++ b/src/record.ts
@@ -1,4 +1,4 @@
-import { store } from './main.js';
+import { store } from '@stonyx/orm';
 import { getComputedProperties } from "./serializer.js";
 import { camelCaseToKebabCase } from '@stonyx/utils/string';
 import { getPluralName } from './plural-registry.js';

--- a/src/relationships.ts
+++ b/src/relationships.ts
@@ -1,4 +1,4 @@
-import { relationships } from './main.js';
+import { relationships } from '@stonyx/orm';
 import type { HasManyMap, BelongsToMap, GlobalMap, PendingMap, PendingBelongsToMap } from './types/orm-types.js';
 
 // TODO: Refactor mapping to remove a level of iteration

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,7 +1,7 @@
 import config from 'stonyx/config';
 import { get, makeArray } from '@stonyx/utils/object';
-import { AggregateProperty } from './aggregates.js';
-import ModelProperty from './model-property.js';
+import type { AggregateProperty } from './aggregates.js';
+import type ModelProperty from './model-property.js';
 
 const RESERVED_KEYS = ['__name'];
 
@@ -93,14 +93,14 @@ export default class Serializer {
       }
 
       // Aggregate property handling — use the rawData value, not the aggregate descriptor
-      if (handler instanceof AggregateProperty) {
+      if ((handler as AggregateProperty)?.__kind === 'AggregateProperty') {
         parsedData[key] = data;
         rec[key] = data;
         continue;
       }
 
       // Direct assignment handling
-      if (!(handler instanceof ModelProperty)) {
+      if ((handler as ModelProperty)?.__kind !== 'ModelProperty') {
         parsedData[key] = handler;
         rec[key] = handler;
         continue;

--- a/src/setup-rest-server.ts
+++ b/src/setup-rest-server.ts
@@ -1,5 +1,5 @@
 import { waitForModule } from 'stonyx';
-import { store } from './main.js';
+import { store } from '@stonyx/orm';
 import OrmRequest from './orm-request.js';
 import MetaRequest from './meta-request.js';
 import RestServer from '@stonyx/rest-server';

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import Orm, { relationships } from './main.js';
+import Orm, { relationships } from '@stonyx/orm';
 import { TYPES, getHasManyRegistry, getBelongsToRegistry, getPendingRegistry } from './relationships.js';
 import ViewResolver from './view-resolver.js';
 

--- a/src/view-resolver.ts
+++ b/src/view-resolver.ts
@@ -1,4 +1,4 @@
-import Orm, { store } from './main.js';
+import Orm, { store } from '@stonyx/orm';
 import { createRecord } from './manage-record.js';
 import { AggregateProperty } from './aggregates.js';
 import { get } from '@stonyx/utils/object';


### PR DESCRIPTION
## Summary

- Reverts internal `./main.js` imports back to `@stonyx/orm` across 17 source files to maintain a single ESM module identity for the `Orm` singleton, `store`, and `relationships` exports
- Adds `__kind` discriminant properties to `AggregateProperty` and `ModelProperty` to replace `instanceof` checks in `serializer.ts` that broke across the `dist/` vs `dist-test/src/` module boundary
- Fixes 67 test failures (52 from singleton split + 15 from instanceof breakage) introduced during Sprint 12

## Root Cause

PR #60 changed imports from `@stonyx/orm` to `./main.js` to "fix circular imports". ESM treats different specifiers as different modules even when they resolve to the same file, splitting the `Orm.instance` singleton. PR #64 then replaced `constructor.name` string checks with `instanceof`, which fails silently across module boundaries.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npm run build:test` clean
- [x] All 602 tests pass (`npm test` → 602/602, 0 failures)

Closes #69

���� Generated with [Claude Code](https://claude.com/claude-code)