### PR TITLE
fix: createRecord updates existing records, format() deduplicates by ID

### DIFF
--- a/src/manage-record.ts
+++ b/src/manage-record.ts
@@ -44,7 +44,12 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
 
   assignRecordId(modelName, rawData);
   const existingRecord = modelStore.get(rawData.id as number | string);
-  if (existingRecord) return existingRecord as OrmRecord;
+
+  if (existingRecord) {
+    // Update the existing record with new data so the last entry wins
+    updateRecord(existingRecord as OrmRecord, rawData, { ...options, update: true });
+    return existingRecord as OrmRecord;
+  }
 
   const recordClasses = orm.getRecordClasses(modelName);
   const modelClass = recordClasses.modelClass as (new (name: string) => { __name: string; [key: string]: unknown }) | undefined;

--- a/src/record.ts
+++ b/src/record.ts
@@ -86,9 +86,24 @@ export default class Record {
     const records: { [key: string]: unknown } = {};
 
     for (const [key, childRecord] of Object.entries(this.__relationships)) {
-      records[key] = Array.isArray(childRecord)
-        ? childRecord.map((r: Record) => r.serialize())
-        : (childRecord as Record)?.serialize() ?? null;
+      if (Array.isArray(childRecord)) {
+        // Deduplicate by record ID — keep last occurrence (latest data wins)
+        const seen = new Set<unknown>();
+        const unique: Record[] = [];
+
+        for (let i = childRecord.length - 1; i >= 0; i--) {
+          const r = childRecord[i] as Record;
+          if (!seen.has(r.id)) {
+            seen.add(r.id);
+            unique.push(r);
+          }
+        }
+
+        unique.reverse();
+        records[key] = unique.map((r: Record) => r.serialize());
+      } else {
+        records[key] = (childRecord as Record)?.serialize() ?? null;
+      }
     }
 
     return { ...data, ...records };

--- a/test/integration/orm-test.js
+++ b/test/integration/orm-test.js
@@ -283,6 +283,59 @@ module('[Integration] ORM', function(hooks) {
       assert.deepEqual(dbRecordData, serialized);
     });
 
+    test('format() deduplicates records by ID in hasMany arrays', function(assert) {
+      // Simulate the corruption scenario: duplicate entries in JSON for the same owner
+      const duplicateData = {
+        owners: [
+          { id: 'gina', name: 'gina', gender: 'female', age: 30, children: 0 },
+          { id: 'gina', name: 'gina', gender: 'female', age: 34, children: 0 }
+        ],
+        animals: [],
+        traits: [],
+        categories: [],
+        phoneNumbers: []
+      };
+
+      // Unload all records and re-create from duplicate data
+      store.unloadAllRecords(dbKey, { includeChildren: true });
+      const dbRecord = createRecord(dbKey, duplicateData, { serialize: false, transform: false });
+      const formatted = dbRecord.format();
+      delete formatted.id;
+
+      assert.strictEqual(formatted.owners.length, 1, 'format() deduplicates — one entry per ID');
+      assert.strictEqual(formatted.owners[0].id, 'gina', 'deduped entry has correct ID');
+      assert.strictEqual(formatted.owners[0].age, 34, 'last entry wins — age is 34 not 30');
+
+      // Restore original data for subsequent tests
+      store.unloadAllRecords(dbKey, { includeChildren: true });
+      createRecord(dbKey, parsedFileData, { serialize: false, transform: false });
+    });
+
+    test('format() round-trip with duplicates preserves record count', function(assert) {
+      // Snapshot the current serialized data
+      const ownerCount = serialized.owners.length;
+
+      // Unload and reload from serialized data
+      store.unloadAllRecords(dbKey, { includeChildren: true });
+      const dbRecord = createRecord(dbKey, serialized, { serialize: false, transform: false });
+      const formatted = dbRecord.format();
+      delete formatted.id;
+
+      assert.strictEqual(formatted.owners.length, ownerCount, 'round-trip preserves exact owner count');
+
+      // Second round-trip should be stable
+      store.unloadAllRecords(dbKey, { includeChildren: true });
+      const dbRecord2 = createRecord(dbKey, formatted, { serialize: false, transform: false });
+      const formatted2 = dbRecord2.format();
+      delete formatted2.id;
+
+      assert.strictEqual(formatted2.owners.length, ownerCount, 'second round-trip is stable — no growth');
+
+      // Restore for subsequent tests
+      store.unloadAllRecords(dbKey, { includeChildren: true });
+      createRecord(dbKey, parsedFileData, { serialize: false, transform: false });
+    });
+
     test('creating a record with a pending relationship works as expected', function(assert) {
       // Note: pets reference animals that do not yet exist
       const record = createRecord('owner', { name: 'testOwner', pets: [ 5000, 5001 ] });

--- a/test/unit/create-record-test.js
+++ b/test/unit/create-record-test.js
@@ -14,3 +14,41 @@ module('[Unit] createRecord | default values', function(hooks) {
     assert.strictEqual(record.gender, undefined, 'nickname should be undefined (not the string "undefined")');
   });
 });
+
+module('[Unit] createRecord | duplicate ID handling', function(hooks) {
+  hooks.afterEach(function() {
+    store.get('owner')?.clear();
+  });
+
+  test('createRecord with duplicate ID updates the existing record', function(assert) {
+    const first = createRecord('owner', { id: 'dup-test', gender: 'female', age: 30 }, { serialize: false });
+
+    assert.strictEqual(first.gender, 'female', 'first record has original gender');
+    assert.strictEqual(first.age, 30, 'first record has original age');
+
+    const second = createRecord('owner', { id: 'dup-test', gender: 'male', age: 35 }, { serialize: false });
+
+    assert.strictEqual(first, second, 'returns the same record object');
+    assert.strictEqual(second.gender, 'male', 'gender was updated to latest value');
+    assert.strictEqual(second.age, 35, 'age was updated to latest value');
+  });
+
+  test('createRecord with duplicate ID does not create a second store entry', function(assert) {
+    createRecord('owner', { id: 'dup-store', gender: 'female' }, { serialize: false });
+    createRecord('owner', { id: 'dup-store', gender: 'male' }, { serialize: false });
+
+    assert.strictEqual(store.get('owner').size, 1, 'store still has exactly one record');
+  });
+
+  test('last entry wins when loading multiple duplicates', function(assert) {
+    createRecord('owner', { id: 'dup-multi', gender: 'female', age: 20 }, { serialize: false });
+    createRecord('owner', { id: 'dup-multi', gender: 'male', age: 30 }, { serialize: false });
+    createRecord('owner', { id: 'dup-multi', gender: 'other', age: 40 }, { serialize: false });
+
+    const record = store.get('owner').get('dup-multi');
+
+    assert.strictEqual(record.gender, 'other', 'final createRecord value wins');
+    assert.strictEqual(record.age, 40, 'final createRecord age wins');
+    assert.strictEqual(store.get('owner').size, 1, 'store has exactly one record');
+  });
+});


### PR DESCRIPTION
## Summary
- **Fix A:** `createRecord` now updates existing records when a duplicate ID is found, ensuring the last entry wins (instead of silently keeping stale first-match data)
- **Fix B:** `format()` deduplicates hasMany relationship arrays by record ID before serializing, breaking the self-reinforcing corruption cycle where duplicates in JSON propagate through save/load

Fixes abofs/stonyx-orm#78
Closes mstonepc/trix#483

## Test plan
- [x] 3 new unit tests for createRecord duplicate ID handling
- [x] 2 new integration tests for format() dedup and round-trip stability
- [x] All 607 existing tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)