### PR TITLE
fix: validate SQL inputs — intervals, identifiers, dimensions, extensions

### DIFF
--- a/src/mysql/migration-runner.ts
+++ b/src/mysql/migration-runner.ts
@@ -2,6 +2,7 @@ import { readFile, fileExists } from '@stonyx/utils/file';
 import path from 'path';
 import fs from 'fs/promises';
 import type { Pool, PoolConnection } from 'mysql2/promise';
+import { validateIdentifier } from './query-builder.js';
 
 interface ParsedMigration {
   up: string;
@@ -9,6 +10,7 @@ interface ParsedMigration {
 }
 
 export async function ensureMigrationsTable(pool: Pool, tableName: string = '__migrations'): Promise<void> {
+  validateIdentifier(tableName, 'migration table name');
   await pool.execute(`
     CREATE TABLE IF NOT EXISTS \`${tableName}\` (
       id INT AUTO_INCREMENT PRIMARY KEY,
@@ -19,6 +21,7 @@ export async function ensureMigrationsTable(pool: Pool, tableName: string = '__m
 }
 
 export async function getAppliedMigrations(pool: Pool, tableName: string = '__migrations'): Promise<string[]> {
+  validateIdentifier(tableName, 'migration table name');
   const [rows] = await pool.execute(
     `SELECT filename FROM \`${tableName}\` ORDER BY id ASC`
   ) as [Array<{ filename: string }>, unknown];
@@ -56,6 +59,7 @@ export function parseMigrationFile(content: string): ParsedMigration {
 }
 
 export async function applyMigration(pool: Pool, filename: string, upSql: string, tableName: string = '__migrations'): Promise<void> {
+  validateIdentifier(tableName, 'migration table name');
   const connection = await pool.getConnection();
 
   try {
@@ -83,6 +87,7 @@ export async function applyMigration(pool: Pool, filename: string, upSql: string
 }
 
 export async function rollbackMigration(pool: Pool, filename: string, downSql: string, tableName: string = '__migrations'): Promise<void> {
+  validateIdentifier(tableName, 'migration table name');
   const connection = await pool.getConnection();
 
   try {

--- a/src/postgres/connection.ts
+++ b/src/postgres/connection.ts
@@ -1,4 +1,5 @@
 import type { Pool as PgPool } from 'pg';
+import { validateIdentifier } from './query-builder.js';
 
 interface PgConfig {
   host: string;
@@ -32,7 +33,8 @@ export async function getPool(pgConfig: PgConfig, extensions: string[] = ['vecto
 
   // Enable requested PostgreSQL extensions
   for (const ext of extensions) {
-    await pool.query(`CREATE EXTENSION IF NOT EXISTS ${ext}`);
+    validateIdentifier(ext, 'extension name');
+    await pool.query(`CREATE EXTENSION IF NOT EXISTS "${ext}"`);
   }
 
   return pool;

--- a/src/postgres/migration-runner.ts
+++ b/src/postgres/migration-runner.ts
@@ -2,8 +2,10 @@ import { readFile, fileExists } from '@stonyx/utils/file';
 import path from 'path';
 import fs from 'fs/promises';
 import type { Pool, PoolClient } from 'pg';
+import { validateIdentifier } from './query-builder.js';
 
 export async function ensureMigrationsTable(pool: Pool, tableName: string = '__migrations'): Promise<void> {
+  validateIdentifier(tableName, 'migration table name');
   await pool.query(`
     CREATE TABLE IF NOT EXISTS "${tableName}" (
       id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -14,6 +16,7 @@ export async function ensureMigrationsTable(pool: Pool, tableName: string = '__m
 }
 
 export async function getAppliedMigrations(pool: Pool, tableName: string = '__migrations'): Promise<string[]> {
+  validateIdentifier(tableName, 'migration table name');
   const result = await pool.query(
     `SELECT filename FROM "${tableName}" ORDER BY id ASC`
   );
@@ -51,6 +54,7 @@ export function parseMigrationFile(content: string): { up: string; down: string 
 }
 
 export async function applyMigration(pool: Pool, filename: string, upSql: string, tableName: string = '__migrations'): Promise<void> {
+  validateIdentifier(tableName, 'migration table name');
   const client: PoolClient = await pool.connect();
 
   try {
@@ -77,6 +81,7 @@ export async function applyMigration(pool: Pool, filename: string, upSql: string
 }
 
 export async function rollbackMigration(pool: Pool, filename: string, downSql: string, tableName: string = '__migrations'): Promise<void> {
+  validateIdentifier(tableName, 'migration table name');
   const client: PoolClient = await pool.connect();
 
   try {

--- a/src/postgres/type-map.ts
+++ b/src/postgres/type-map.ts
@@ -42,6 +42,10 @@ export function getPgType(attrType: string, transformFn?: TransformFn): string {
  * Returns a vector column type for the given dimensions.
  */
 export function getVectorType(dimensions: number): string {
+  if (!Number.isInteger(dimensions) || dimensions < 1 || dimensions > 16000) {
+    throw new Error(`Invalid vector dimensions: ${dimensions}. Must be an integer between 1 and 16000.`);
+  }
+
   return `vector(${dimensions})`;
 }
 

--- a/src/timescale/query-builder.ts
+++ b/src/timescale/query-builder.ts
@@ -3,6 +3,26 @@ export { validateIdentifier, buildInsert, buildUpdate, buildDelete, buildSelect 
 
 import { validateIdentifier } from '../postgres/query-builder.js';
 
+const SAFE_INTERVAL = /^\d+\s+(microsecond|millisecond|second|minute|hour|day|week|month|year)s?$/i;
+
+export function validateInterval(interval: string, context: string = 'interval'): string {
+  if (!interval || typeof interval !== 'string' || !SAFE_INTERVAL.test(interval.trim())) {
+    throw new Error(`Invalid SQL ${context}: "${interval}". Intervals must match pattern like "7 days", "1 hour", "30 minutes".`);
+  }
+
+  return interval.trim();
+}
+
+const SAFE_AGGREGATE = /^(COUNT|SUM|AVG|MIN|MAX|FIRST|LAST)\s*\(\s*"?[a-zA-Z_][a-zA-Z0-9_]*"?\s*\)\s*(AS\s+"?[a-zA-Z_][a-zA-Z0-9_]*"?)?$/i;
+
+export function validateAggregate(expr: string, context: string = 'aggregate'): string {
+  if (!expr || typeof expr !== 'string' || !SAFE_AGGREGATE.test(expr.trim())) {
+    throw new Error(`Invalid SQL ${context}: "${expr}". Aggregates must be simple function calls like "AVG(value) AS avg_value".`);
+  }
+
+  return expr.trim();
+}
+
 interface QueryResult {
   sql: string;
   values: unknown[];
@@ -36,6 +56,7 @@ export function buildCreateHypertable(table: string, timeColumn: string, options
   validateIdentifier(timeColumn, 'column name');
 
   const { chunkInterval = '7 days' } = options;
+  validateInterval(chunkInterval, 'chunk interval');
 
   const sql = `SELECT create_hypertable('"${table}"', '${timeColumn}', chunk_time_interval => INTERVAL '${chunkInterval}', if_not_exists => TRUE)`;
 
@@ -57,7 +78,7 @@ export function buildTimeBucket(table: string, timeColumn: string, bucketSize: s
   values.push(bucketSize);
 
   for (const agg of aggregates) {
-    selectCols.push(agg);
+    selectCols.push(validateAggregate(agg));
   }
 
   const whereClauses: string[] = [];
@@ -70,7 +91,8 @@ export function buildTimeBucket(table: string, timeColumn: string, bucketSize: s
   }
 
   const whereStr = whereClauses.length > 0 ? ` WHERE ${whereClauses.join(' AND ')}` : '';
-  const orderStr = orderBy ? ` ORDER BY ${orderBy}` : '';
+  if (orderBy) validateIdentifier(orderBy, 'ORDER BY column');
+  const orderStr = orderBy ? ` ORDER BY "${orderBy}"` : '';
   let limitStr = '';
   if (limit != null) {
     limitStr = ` LIMIT $${paramIndex++}`;
@@ -91,6 +113,8 @@ export function buildContinuousAggregate(viewName: string, table: string, timeCo
   validateIdentifier(timeColumn, 'column name');
 
   const { withNoData = false } = options;
+  validateInterval(bucketSize, 'bucket size');
+  aggregates.forEach(agg => validateAggregate(agg));
 
   const selectCols: string[] = [
     `time_bucket('${bucketSize}', "${timeColumn}") AS bucket`,
@@ -109,6 +133,7 @@ export function buildContinuousAggregate(viewName: string, table: string, timeCo
  */
 export function buildCompressionPolicy(table: string, compressAfter: string): SqlResult {
   validateIdentifier(table, 'table name');
+  validateInterval(compressAfter, 'compress after interval');
 
   const sql = `SELECT add_compression_policy('"${table}"', INTERVAL '${compressAfter}', if_not_exists => TRUE)`;
 

--- a/src/timescale/query-builder.ts
+++ b/src/timescale/query-builder.ts
@@ -13,7 +13,7 @@ export function validateInterval(interval: string, context: string = 'interval')
   return interval.trim();
 }
 
-const SAFE_AGGREGATE = /^(COUNT|SUM|AVG|MIN|MAX|FIRST|LAST)\s*\(\s*"?[a-zA-Z_][a-zA-Z0-9_]*"?\s*\)\s*(AS\s+"?[a-zA-Z_][a-zA-Z0-9_]*"?)?$/i;
+const SAFE_AGGREGATE = /^(COUNT|SUM|AVG|MIN|MAX|FIRST|LAST)\s*\(\s*("?[a-zA-Z_][a-zA-Z0-9_]*"?|\*)\s*\)\s*(AS\s+"?[a-zA-Z_][a-zA-Z0-9_]*"?)?$/i;
 
 export function validateAggregate(expr: string, context: string = 'aggregate'): string {
   if (!expr || typeof expr !== 'string' || !SAFE_AGGREGATE.test(expr.trim())) {
@@ -91,8 +91,20 @@ export function buildTimeBucket(table: string, timeColumn: string, bucketSize: s
   }
 
   const whereStr = whereClauses.length > 0 ? ` WHERE ${whereClauses.join(' AND ')}` : '';
-  if (orderBy) validateIdentifier(orderBy, 'ORDER BY column');
-  const orderStr = orderBy ? ` ORDER BY "${orderBy}"` : '';
+  let orderStr = '';
+  if (orderBy) {
+    const parts = orderBy.trim().split(/\s+/);
+    const col = parts[0];
+    const dir = parts[1]?.toUpperCase();
+
+    validateIdentifier(col, 'ORDER BY column');
+
+    if (dir && dir !== 'ASC' && dir !== 'DESC') {
+      throw new Error(`Invalid ORDER BY direction: "${dir}". Must be ASC or DESC.`);
+    }
+
+    orderStr = ` ORDER BY "${col}"${dir ? ` ${dir}` : ''}`;
+  }
   let limitStr = '';
   if (limit != null) {
     limitStr = ` LIMIT $${paramIndex++}`;

--- a/test/unit/postgres/sql-validation-test.js
+++ b/test/unit/postgres/sql-validation-test.js
@@ -1,0 +1,105 @@
+import QUnit from 'qunit';
+import { validateInterval, validateAggregate } from '../../../src/timescale/query-builder.js';
+import { getVectorType } from '../../../src/postgres/type-map.js';
+
+const { module, test } = QUnit;
+
+module('[Unit] SQL Validation — validateInterval', function () {
+  test('accepts valid interval strings', function (assert) {
+    assert.strictEqual(validateInterval('7 days'), '7 days');
+    assert.strictEqual(validateInterval('1 hour'), '1 hour');
+    assert.strictEqual(validateInterval('30 minutes'), '30 minutes');
+    assert.strictEqual(validateInterval('1 second'), '1 second');
+    assert.strictEqual(validateInterval('12 months'), '12 months');
+    assert.strictEqual(validateInterval('1 year'), '1 year');
+    assert.strictEqual(validateInterval('500 milliseconds'), '500 milliseconds');
+    assert.strictEqual(validateInterval('1 week'), '1 week');
+  });
+
+  test('accepts intervals with leading/trailing whitespace', function (assert) {
+    assert.strictEqual(validateInterval('  7 days  '), '7 days');
+  });
+
+  test('rejects SQL injection in intervals', function (assert) {
+    assert.throws(
+      () => validateInterval("7 days'; DROP TABLE users; --"),
+      /Invalid SQL interval/,
+      'SQL injection rejected'
+    );
+  });
+
+  test('rejects empty or non-string intervals', function (assert) {
+    assert.throws(() => validateInterval(''), /Invalid SQL interval/);
+    assert.throws(() => validateInterval(null), /Invalid SQL interval/);
+    assert.throws(() => validateInterval(undefined), /Invalid SQL interval/);
+  });
+
+  test('rejects arbitrary expressions', function (assert) {
+    assert.throws(
+      () => validateInterval('INTERVAL 7 days'),
+      /Invalid SQL interval/,
+      'rejects INTERVAL keyword prefix'
+    );
+    assert.throws(
+      () => validateInterval('7'),
+      /Invalid SQL interval/,
+      'rejects bare number without unit'
+    );
+  });
+});
+
+module('[Unit] SQL Validation — validateAggregate', function () {
+  test('accepts valid aggregate expressions', function (assert) {
+    assert.strictEqual(validateAggregate('COUNT(value)'), 'COUNT(value)');
+    assert.strictEqual(validateAggregate('AVG(temperature) AS avg_temp'), 'AVG(temperature) AS avg_temp');
+    assert.strictEqual(validateAggregate('SUM(amount)'), 'SUM(amount)');
+    assert.strictEqual(validateAggregate('MIN(price)'), 'MIN(price)');
+    assert.strictEqual(validateAggregate('MAX(score)'), 'MAX(score)');
+  });
+
+  test('rejects SQL injection in aggregates', function (assert) {
+    assert.throws(
+      () => validateAggregate('COUNT(*) FROM users; DROP TABLE users; --'),
+      /Invalid SQL aggregate/,
+      'SQL injection rejected'
+    );
+  });
+
+  test('rejects arbitrary subqueries', function (assert) {
+    assert.throws(
+      () => validateAggregate('(SELECT password FROM users LIMIT 1)'),
+      /Invalid SQL aggregate/,
+      'subquery rejected'
+    );
+  });
+
+  test('rejects empty or non-string aggregates', function (assert) {
+    assert.throws(() => validateAggregate(''), /Invalid SQL aggregate/);
+    assert.throws(() => validateAggregate(null), /Invalid SQL aggregate/);
+  });
+});
+
+module('[Unit] SQL Validation — getVectorType dimensions', function () {
+  test('accepts valid dimensions', function (assert) {
+    assert.strictEqual(getVectorType(3), 'vector(3)');
+    assert.strictEqual(getVectorType(1536), 'vector(1536)');
+    assert.strictEqual(getVectorType(1), 'vector(1)');
+    assert.strictEqual(getVectorType(16000), 'vector(16000)');
+  });
+
+  test('rejects zero dimensions', function (assert) {
+    assert.throws(() => getVectorType(0), /Invalid vector dimensions/);
+  });
+
+  test('rejects negative dimensions', function (assert) {
+    assert.throws(() => getVectorType(-1), /Invalid vector dimensions/);
+  });
+
+  test('rejects dimensions exceeding limit', function (assert) {
+    assert.throws(() => getVectorType(16001), /Invalid vector dimensions/);
+  });
+
+  test('rejects non-integer dimensions', function (assert) {
+    assert.throws(() => getVectorType(3.14), /Invalid vector dimensions/);
+  });
+});

--- a/test/unit/postgres/sql-validation-test.js
+++ b/test/unit/postgres/sql-validation-test.js
@@ -1,5 +1,5 @@
 import QUnit from 'qunit';
-import { validateInterval, validateAggregate } from '../../../src/timescale/query-builder.js';
+import { validateInterval, validateAggregate, buildTimeBucket } from '../../../src/timescale/query-builder.js';
 import { getVectorType } from '../../../src/postgres/type-map.js';
 
 const { module, test } = QUnit;
@@ -55,6 +55,8 @@ module('[Unit] SQL Validation — validateAggregate', function () {
     assert.strictEqual(validateAggregate('SUM(amount)'), 'SUM(amount)');
     assert.strictEqual(validateAggregate('MIN(price)'), 'MIN(price)');
     assert.strictEqual(validateAggregate('MAX(score)'), 'MAX(score)');
+    assert.strictEqual(validateAggregate('COUNT(*)'), 'COUNT(*)');
+    assert.strictEqual(validateAggregate('COUNT(*) AS reading_count'), 'COUNT(*) AS reading_count');
   });
 
   test('rejects SQL injection in aggregates', function (assert) {
@@ -76,6 +78,34 @@ module('[Unit] SQL Validation — validateAggregate', function () {
   test('rejects empty or non-string aggregates', function (assert) {
     assert.throws(() => validateAggregate(''), /Invalid SQL aggregate/);
     assert.throws(() => validateAggregate(null), /Invalid SQL aggregate/);
+  });
+});
+
+module('[Unit] SQL Validation — buildTimeBucket orderBy', function () {
+  test('accepts simple column name for orderBy', function (assert) {
+    const result = buildTimeBucket('test_table', 'created_at', '1 hour', { orderBy: 'bucket' });
+    assert.ok(result.sql.includes('ORDER BY "bucket"'), 'orderBy column is quoted');
+  });
+
+  test('accepts column name with ASC/DESC direction', function (assert) {
+    const result = buildTimeBucket('test_table', 'created_at', '1 hour', { orderBy: 'bucket DESC' });
+    assert.ok(result.sql.includes('ORDER BY "bucket" DESC'), 'orderBy with direction is parsed correctly');
+  });
+
+  test('rejects invalid orderBy direction', function (assert) {
+    assert.throws(
+      () => buildTimeBucket('test_table', 'created_at', '1 hour', { orderBy: 'bucket SIDEWAYS' }),
+      /Invalid ORDER BY direction/,
+      'invalid direction rejected'
+    );
+  });
+
+  test('rejects SQL injection in orderBy', function (assert) {
+    assert.throws(
+      () => buildTimeBucket('test_table', 'created_at', '1 hour', { orderBy: 'bucket; DROP TABLE' }),
+      /Invalid/,
+      'SQL injection in orderBy rejected'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `validateInterval()` for TimescaleDB interval parameters (chunkInterval, bucketSize, compressAfter) — rejects SQL injection via malformed intervals
- Add `validateAggregate()` for TimescaleDB aggregate expressions — whitelist of safe aggregate functions
- Validate migration table names with `validateIdentifier()` in both PostgreSQL and MySQL runners
- Validate + quote PostgreSQL extension names in connection setup
- Validate ORDER BY columns in time-bucket queries
- Add bounds checking (1–16000) for vector dimensions in `getVectorType()`

Fixes abofs/stonyx-orm#83

## Scope note
SAFE_IDENTIFIER regex intentionally retains hyphens — the Stonyx ecosystem uses kebab-case model names (e.g., `phone-number`), and all SQL identifiers are already quoted.

## Test plan
- [x] 14 new unit tests for validateInterval, validateAggregate, getVectorType bounds
- [x] All 621 tests pass (607 existing + 14 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)