### PR TITLE
fix: strengthen type declarations across .d.ts and core types

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -167,7 +167,7 @@ export default class DB {
       await Promise.all(collectionKeys.map(async key => {
         const filePath = path.join(dirPath, `${key}.json`);
         const exists = await fileExists(filePath);
-        const data = jsonData[key] || [];
+        const data = (jsonData[key] || []) as Record<string, unknown> | unknown[];
 
         if (exists) await updateFile(filePath, data, { json: true });
         else await createFile(filePath, data, { json: true });

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -19,7 +19,23 @@
  * Unlike event-based hooks, middleware hooks run sequentially and can halt operations.
  */
 
-type HookHandler = (context: Record<string, unknown>) => unknown | Promise<unknown>;
+export interface HookContext {
+  model: string;
+  operation: string;
+  request?: unknown;
+  params?: Record<string, string>;
+  body?: Record<string, unknown>;
+  query?: Record<string, string>;
+  state?: Record<string, unknown>;
+  oldState?: unknown;
+  recordId?: string | number;
+  response?: unknown;
+  record?: unknown;
+  records?: unknown[];
+  [key: string]: unknown;
+}
+
+type HookHandler = (context: HookContext) => unknown | Promise<unknown>;
 
 // Map of "operation:model" -> handler[]
 const beforeHooks: Map<string, HookHandler[]> = new Map();

--- a/src/orm-request.ts
+++ b/src/orm-request.ts
@@ -3,6 +3,7 @@ import Orm, { store, createRecord, updateRecord } from '@stonyx/orm';
 import { camelCaseToKebabCase } from '@stonyx/utils/string';
 import { getPluralName } from './plural-registry.js';
 import { getBeforeHooks, getAfterHooks } from './hooks.js';
+import type { HookContext } from './hooks.js';
 import config from 'stonyx/config';
 import type { OrmRecord } from './types/orm-types.js';
 import { isOrmRecord } from './utils.js';
@@ -24,22 +25,6 @@ interface RelationshipInfo {
 interface Filter {
   path: string[];
   value: string;
-}
-
-interface HookContext {
-  model: string;
-  operation: string;
-  request: OrmRequest$;
-  params: { [key: string]: string };
-  body?: { [key: string]: unknown };
-  query?: { [key: string]: string };
-  state: { [key: string]: unknown };
-  oldState?: unknown;
-  recordId?: string | number;
-  response?: unknown;
-  record?: unknown;
-  records?: unknown;
-  [key: string]: unknown;
 }
 
 interface JsonApiResponse {

--- a/src/postgres/postgres-db.ts
+++ b/src/postgres/postgres-db.ts
@@ -507,7 +507,7 @@ export default class PostgresDB {
     // Re-key the record in the store if PostgreSQL generated the ID (via RETURNING)
     if (isPendingId && result.rows.length > 0) {
       const pendingId = record.id;
-      const realId = result.rows[0].id;
+      const realId = result.rows[0].id as string | number;
       const modelStore = (this.deps.store as unknown as { get(name: string): Map<unknown, unknown> }).get(modelName);
 
       modelStore.delete(pendingId);

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -33,7 +33,7 @@ function query(rawData: unknown, pathPrefix: string, subPath: unknown): unknown 
 
   const [path, getter, pointer] = makeArray(subPath) as [string, unknown, string | undefined];
   const fullPath = `${pathPrefix}${path}`;
-  const value = get(rawData, fullPath);
+  const value = get(rawData as Record<string, unknown>, fullPath);
 
   if (getter === undefined || getter === null) return value;
 

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -7,7 +7,7 @@ const transforms: Record<string, (value: unknown) => unknown> = {
   number: (value: unknown) => parseInt(value as string),
   passthrough: (value: unknown) => value,
   string: (value: unknown) => String(value),
-  timestamp: (value: unknown) => getTimestamp(value),
+  timestamp: (value: unknown) => getTimestamp(value as string | number | Date | undefined),
   trim: (value: unknown) => (value as string)?.trim(),
   uppercase: (value: unknown) => (value as string)?.toUpperCase(),
 };

--- a/src/types/mysql2.d.ts
+++ b/src/types/mysql2.d.ts
@@ -5,16 +5,35 @@ declare module 'mysql2/promise' {
     password: string;
     database: string;
     port?: number;
-    [key: string]: unknown;
+    waitForConnections?: boolean;
+    connectionLimit?: number;
+    queueLimit?: number;
+    enableKeepAlive?: boolean;
+    keepAliveInitialDelay?: number;
+    [key: string]: string | number | boolean | undefined;
   }
 
-  interface QueryResult {
-    [index: number]: unknown;
+  interface ExecuteResult {
+    insertId: number;
+    affectedRows: number;
+    changedRows: number;
+    fieldCount: number;
+    info: string;
+    serverStatus: number;
+    warningStatus: number;
   }
+
+  interface FieldPacket {
+    name: string;
+    type: number;
+    length: number;
+  }
+
+  type RowDataPacket = Record<string, string | number | boolean | null>;
 
   interface Pool {
-    execute(sql: string, params?: unknown[]): Promise<[unknown[], unknown]>;
-    query(sql: string, params?: unknown[]): Promise<[unknown[], unknown]>;
+    execute(sql: string, params?: unknown[]): Promise<[RowDataPacket[] | ExecuteResult, FieldPacket[]]>;
+    query(sql: string, params?: unknown[]): Promise<[RowDataPacket[] | ExecuteResult, FieldPacket[]]>;
     end(): Promise<void>;
     getConnection(): Promise<PoolConnection>;
   }

--- a/src/types/orm-types.ts
+++ b/src/types/orm-types.ts
@@ -6,7 +6,7 @@ export interface OrmDbConfig {
   mode: string;
   directory: string;
   autosave: string;
-  saveInterval: unknown;
+  saveInterval: string | number;
 }
 
 export interface OrmMysqlConfig {
@@ -68,16 +68,16 @@ export interface SourceRecord {
   __model: { __name: string; [key: string]: unknown };
   __data?: Record<string, unknown>;
   __relationships?: Record<string, unknown>;
-  id: unknown;
+  id: string | number;
   [key: string]: unknown;
 }
 
 export interface OrmRecord {
-  id: string | number | unknown;
+  id: string | number;
   __model?: { __name: string };
-  __data: Record<string, unknown> & { id?: unknown; __pendingSqlId?: boolean };
+  __data: Record<string, unknown> & { id?: string | number; __pendingSqlId?: boolean };
   __relationships: Record<string, unknown>;
-  toJSON?(options?: { fields?: Set<string>; baseUrl?: string }): unknown;
+  toJSON?(options?: { fields?: Set<string>; baseUrl?: string }): Record<string, unknown>;
   [key: string]: unknown;
 }
 

--- a/src/types/pg.d.ts
+++ b/src/types/pg.d.ts
@@ -5,13 +5,17 @@ declare module 'pg' {
     password?: string;
     database?: string;
     port?: number;
-    [key: string]: unknown;
+    max?: number;
+    idleTimeoutMillis?: number;
+    connectionTimeoutMillis?: number;
   }
 
+  type RowData = Record<string, string | number | boolean | null>;
+
   interface QueryResult {
-    rows: Record<string, unknown>[];
+    rows: RowData[];
     rowCount: number;
-    fields?: { name: string }[];
+    fields?: { name: string; dataTypeID: number }[];
   }
 
   export class Pool {

--- a/src/types/stonyx-rest-server.d.ts
+++ b/src/types/stonyx-rest-server.d.ts
@@ -3,9 +3,14 @@ declare module '@stonyx/rest-server' {
     constructor(...args: unknown[]);
   }
 
+  interface RouteOptions {
+    name: string;
+    options?: { model: string; access: (request: unknown) => unknown } | Record<string, unknown>;
+  }
+
   export default class RestServer {
     static instance: RestServer;
     static close(): void;
-    mountRoute(RequestClass: unknown, options: { name: string; options?: unknown }): void;
+    mountRoute(RequestClass: typeof Request, options: RouteOptions): void;
   }
 }

--- a/src/types/stonyx-utils.d.ts
+++ b/src/types/stonyx-utils.d.ts
@@ -1,13 +1,13 @@
 declare module '@stonyx/utils/file' {
-  export function createFile(path: string, data: unknown, options?: { json?: boolean }): Promise<void>;
+  export function createFile(path: string, data: string | Record<string, unknown> | unknown[], options?: { json?: boolean }): Promise<void>;
   export function createDirectory(path: string): Promise<void>;
-  export function updateFile(path: string, data: unknown, options?: { json?: boolean }): Promise<void>;
-  export function readFile(path: string, options?: { json?: boolean; missingFileCallback?: () => Promise<unknown> }): Promise<unknown>;
+  export function updateFile(path: string, data: string | Record<string, unknown> | unknown[], options?: { json?: boolean }): Promise<void>;
+  export function readFile(path: string, options?: { json?: boolean; missingFileCallback?: () => Promise<Record<string, unknown>> }): Promise<string | Record<string, unknown> | unknown[]>;
   export function fileExists(path: string): Promise<boolean>;
   export function deleteDirectory(path: string): Promise<void>;
   export function forEachFileImport(
     path: string,
-    callback: (exported: unknown, meta: { name: string }) => unknown,
+    callback: (exported: Function | Record<string, unknown>, meta: { name: string }) => void | unknown,
     options?: { ignoreAccessFailure?: boolean; rawName?: boolean; recursive?: boolean; recursiveNaming?: boolean }
   ): Promise<void>;
 }
@@ -19,13 +19,13 @@ declare module '@stonyx/utils/string' {
 }
 
 declare module '@stonyx/utils/object' {
-  export function get(obj: unknown, path: string): unknown;
+  export function get(obj: Record<string, unknown>, path: string): unknown;
   export function getOrSet<T>(map: Map<unknown, T>, key: unknown, defaultValue: T): T;
   export function makeArray<T>(value: T | T[]): T[];
 }
 
 declare module '@stonyx/utils/date' {
-  export function getTimestamp(value?: unknown): number;
+  export function getTimestamp(value?: string | number | Date): number;
 }
 
 declare module '@stonyx/utils/prompt' {


### PR DESCRIPTION
## Summary
- Tightened ambient module declarations (mysql2, pg, stonyx-utils, stonyx-rest-server) with accurate return types, interfaces, and parameter shapes
- Narrowed `OrmRecord.id` from `unknown` to `string | number` and `saveInterval` to `string | number`
- Added exported `HookContext` interface in hooks.ts, removed duplicate from orm-request.ts
- Fixed downstream type mismatches in db.ts, postgres-db.ts, serializer.ts, and transforms.ts

Closes #82

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Full test suite passes (625/625)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)