### PR TITLE
fix: extract shared schema helpers, add JSDoc, improve clarity

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -19,18 +19,31 @@
  * Unlike event-based hooks, middleware hooks run sequentially and can halt operations.
  */
 
+/** Context object passed to before/after hook handlers. */
 export interface HookContext {
+  /** Model name (e.g. 'user', 'animal'). */
   model: string;
+  /** Operation name: 'create', 'update', 'delete', 'get', or 'list'. */
   operation: string;
+  /** The incoming HTTP request object. */
   request?: unknown;
+  /** URL route parameters (e.g. { id: '42' }). */
   params?: Record<string, string>;
+  /** Parsed request body for create/update operations. */
   body?: Record<string, unknown>;
+  /** URL query string parameters. */
   query?: Record<string, string>;
+  /** Mutable state bag shared across hooks within a single request. */
   state?: Record<string, unknown>;
+  /** Previous record state (available in update hooks). */
   oldState?: unknown;
+  /** Target record ID for single-record operations. */
   recordId?: string | number;
+  /** Response data (available in after hooks). */
   response?: unknown;
+  /** The affected record (available in after hooks for create/update/delete). */
   record?: unknown;
+  /** The affected records (available in after hooks for list operations). */
   records?: unknown[];
   [key: string]: unknown;
 }

--- a/src/mysql/schema-introspector.ts
+++ b/src/mysql/schema-introspector.ts
@@ -4,37 +4,13 @@ import { camelCaseToKebabCase } from '@stonyx/utils/string';
 import { getPluralName } from '../plural-registry.js';
 import { dbKey } from '../db.js';
 import { AggregateProperty } from '../aggregates.js';
+import { getRelationshipInfo, sanitizeTableName } from '../schema-helpers.js';
 import type { ForeignKeyDef, ModelSchema, ViewSchema, SnapshotEntry } from '../types/orm-types.js';
 import ModelProperty from '../model-property.js';
-
-interface RelationshipInfo {
-  type: 'belongsTo' | 'hasMany';
-  modelName: string | null;
-}
 
 interface JoinClause {
   table: string;
   condition: string;
-}
-
-interface RelationshipProperty {
-  __relatedModelName?: string | null;
-  __relationshipType?: string;
-}
-
-function getRelationshipInfo(property: unknown): RelationshipInfo | null {
-  if (typeof property !== 'function') return null;
-  const relType = (property as RelationshipProperty).__relationshipType;
-  const modelName = (property as RelationshipProperty).__relatedModelName || null;
-
-  if (relType === 'belongsTo') return { type: 'belongsTo', modelName };
-  if (relType === 'hasMany') return { type: 'hasMany', modelName };
-
-  return null;
-}
-
-function sanitizeTableName(name: string): string {
-  return name.replace(/[-/]/g, '_');
 }
 
 export function introspectModels(): Record<string, ModelSchema> {
@@ -143,31 +119,7 @@ function getReferencedIdType(tableName: string, allSchemas: Record<string, Model
   return 'INT';
 }
 
-export function getTopologicalOrder(schemas: Record<string, ModelSchema>): string[] {
-  const visited = new Set<string>();
-  const order: string[] = [];
-
-  function visit(name: string): void {
-    if (visited.has(name)) return;
-    visited.add(name);
-
-    const schema = schemas[name];
-    if (!schema) return;
-
-    // Visit dependencies (belongsTo targets) first
-    for (const targetModelName of Object.values(schema.relationships.belongsTo)) {
-      if (targetModelName) visit(targetModelName);
-    }
-
-    order.push(name);
-  }
-
-  for (const name of Object.keys(schemas)) {
-    visit(name);
-  }
-
-  return order;
-}
+export { getTopologicalOrder } from '../schema-helpers.js';
 
 export function introspectViews(): Record<string, ViewSchema> {
   const orm = (Orm as unknown as { instance: { views?: Record<string, unknown>; transforms: Record<string, unknown> } }).instance;

--- a/src/orm-request.ts
+++ b/src/orm-request.ts
@@ -577,5 +577,6 @@ export default class OrmRequest extends Request {
     if (!access) return 403;
     if (Array.isArray(access) && !access.includes(methodAccessMap[request.method])) return 403;
     if (typeof access === 'function') state.filter = access;
+    return undefined;
   }
 }

--- a/src/postgres/schema-introspector.ts
+++ b/src/postgres/schema-introspector.ts
@@ -4,13 +4,9 @@ import { camelCaseToKebabCase } from '@stonyx/utils/string';
 import { getPluralName } from '../plural-registry.js';
 import { dbKey } from '../db.js';
 import { AggregateProperty } from '../aggregates.js';
+import { getRelationshipInfo, sanitizeTableName } from '../schema-helpers.js';
 import type { ForeignKeyDef, ModelSchema, ViewSchema } from '../types/orm-types.js';
 import ModelProperty from '../model-property.js';
-
-interface RelationshipInfo {
-  type: 'belongsTo' | 'hasMany';
-  modelName: string | null;
-}
 
 interface ViewSnapshotEntry {
   viewName: string;
@@ -33,21 +29,6 @@ interface ModelSnapshotEntry {
 interface JoinDef {
   table: string;
   condition: string;
-}
-
-function getRelationshipInfo(property: unknown): RelationshipInfo | null {
-  if (typeof property !== 'function') return null;
-  const relType = (property as { __relationshipType?: string }).__relationshipType;
-  const modelName = (property as { __relatedModelName?: string }).__relatedModelName || null;
-
-  if (relType === 'belongsTo') return { type: 'belongsTo', modelName };
-  if (relType === 'hasMany') return { type: 'hasMany', modelName };
-
-  return null;
-}
-
-function sanitizeTableName(name: string): string {
-  return name.replace(/[-/]/g, '_');
 }
 
 export function introspectModels(): Record<string, ModelSchema> {
@@ -177,31 +158,7 @@ function getReferencedIdType(tableName: string, allSchemas: Record<string, Model
   return 'INTEGER';
 }
 
-export function getTopologicalOrder(schemas: Record<string, ModelSchema>): string[] {
-  const visited = new Set<string>();
-  const order: string[] = [];
-
-  function visit(name: string): void {
-    if (visited.has(name)) return;
-    visited.add(name);
-
-    const schema = schemas[name];
-    if (!schema) return;
-
-    // Visit dependencies (belongsTo targets) first
-    for (const targetModelName of Object.values(schema.relationships.belongsTo)) {
-      if (targetModelName) visit(targetModelName);
-    }
-
-    order.push(name);
-  }
-
-  for (const name of Object.keys(schemas)) {
-    visit(name);
-  }
-
-  return order;
-}
+export { getTopologicalOrder } from '../schema-helpers.js';
 
 export function introspectViews(): Record<string, ViewSchema> {
   const orm = Orm.instance as { views?: Record<string, unknown> };

--- a/src/schema-helpers.ts
+++ b/src/schema-helpers.ts
@@ -1,0 +1,59 @@
+import type { ModelSchema } from './types/orm-types.js';
+
+export interface SchemaRelationshipInfo {
+  type: 'belongsTo' | 'hasMany';
+  modelName: string | null;
+}
+
+/**
+ * Detect relationship type and target model from a model property function.
+ * Returns null if the property is not a relationship.
+ */
+export function getRelationshipInfo(property: unknown): SchemaRelationshipInfo | null {
+  if (typeof property !== 'function') return null;
+  const relType = (property as { __relationshipType?: string }).__relationshipType;
+  const modelName = (property as { __relatedModelName?: string }).__relatedModelName || null;
+
+  if (relType === 'belongsTo') return { type: 'belongsTo', modelName };
+  if (relType === 'hasMany') return { type: 'hasMany', modelName };
+
+  return null;
+}
+
+/**
+ * Sanitize a model/table name for use in SQL identifiers.
+ * Replaces hyphens and slashes with underscores.
+ */
+export function sanitizeTableName(name: string): string {
+  return name.replace(/[-/]/g, '_');
+}
+
+/**
+ * Sort model schemas in dependency order (belongsTo targets before dependents).
+ * Uses depth-first traversal to ensure referenced tables are created first.
+ */
+export function getTopologicalOrder(schemas: Record<string, ModelSchema>): string[] {
+  const visited = new Set<string>();
+  const order: string[] = [];
+
+  function visit(name: string): void {
+    if (visited.has(name)) return;
+    visited.add(name);
+
+    const schema = schemas[name];
+    if (!schema) return;
+
+    // Visit dependencies (belongsTo targets) first
+    for (const targetModelName of Object.values(schema.relationships.belongsTo)) {
+      if (targetModelName) visit(targetModelName);
+    }
+
+    order.push(name);
+  }
+
+  for (const name of Object.keys(schemas)) {
+    visit(name);
+  }
+
+  return order;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -185,14 +185,14 @@ export default class Store {
     const modelStore = this.data.get(model);
 
     if (!modelStore) {
-      console.warn(`[Store] Cannot unload record: model "${model}" not found in store`);
+      console.warn(`[Store] Cannot unload record: model "${model}" not found in store — ensure the model is registered before unloading`);
       return;
     }
 
     if (typeof id !== 'string' && typeof id !== 'number') return;
     const raw = modelStore.get(id);
     if (!raw || !isStoreRecord(raw)) {
-      console.warn(`[Store] Cannot unload record: ${model}:${id} not found in store`);
+      console.warn(`[Store] Cannot unload record: ${model}:${id} not found in store — it may have already been unloaded`);
       return;
     }
     const record = raw;
@@ -217,7 +217,7 @@ export default class Store {
     const modelStore = this.data.get(model);
 
     if (!modelStore) {
-      console.warn(`[Store] Cannot unload all records: model "${model}" not found in store`);
+      console.warn(`[Store] Cannot unload all records: model "${model}" not found in store — ensure the model is registered before unloading`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Extracted `getTopologicalOrder`, `getRelationshipInfo`, and `sanitizeTableName` into shared `schema-helpers.ts` — eliminates identical duplicates from mysql and postgres schema introspectors
- Added JSDoc to all `HookContext` interface fields
- Added explicit `return undefined` to `auth()` implicit return path
- Improved store unload warning messages with remediation hints

Closes #84

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Full test suite passes (625/625)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)