### PR TITLE
feat: TimescaleDB hypertable support in migration generator

### DIFF
--- a/src/postgres/migration-generator.ts
+++ b/src/postgres/migration-generator.ts
@@ -1,4 +1,5 @@
 import { introspectModels, introspectViews, buildTableDDL, buildViewDDL, buildVectorIndexDDL, schemasToSnapshot, viewSchemasToSnapshot, getTopologicalOrder } from './schema-introspector.js';
+import { buildCreateHypertable, buildEnableCompression, buildCompressionPolicy } from '../timescale/query-builder.js';
 import { readFile, createFile, createDirectory, fileExists } from '@stonyx/utils/file';
 import path from 'path';
 import config from 'stonyx/config';
@@ -95,6 +96,27 @@ export async function generateMigration(description: string = 'migration', confi
     }
 
     downStatements.unshift(`DROP TABLE IF EXISTS "${schemas[name].table}" CASCADE;`);
+  }
+
+  // Hypertable conversion + compression (TimescaleDB only)
+  if (configKey === 'timescale') {
+    for (const name of addedOrdered) {
+      const schema = schemas[name];
+      if (!schema.hypertable) continue;
+
+      const { timeColumn, chunkInterval } = schema.hypertable;
+      upStatements.push(buildCreateHypertable(schema.table, timeColumn, { chunkInterval }).sql + ';');
+
+      if (schema.hypertable.compress) {
+        const { segmentBy, orderBy, after } = schema.hypertable.compress;
+        upStatements.push(buildEnableCompression(schema.table, segmentBy, orderBy).sql + ';');
+        if (after) {
+          upStatements.push(buildCompressionPolicy(schema.table, after).sql + ';');
+        }
+      }
+
+      downStatements.unshift('-- Hypertable conversion is not reversible; table drop handles cleanup');
+    }
   }
 
   // Removed tables (warn only, commented out)

--- a/src/postgres/schema-introspector.ts
+++ b/src/postgres/schema-introspector.ts
@@ -5,7 +5,7 @@ import { getPluralName } from '../plural-registry.js';
 import { dbKey } from '../db.js';
 import { AggregateProperty } from '../aggregates.js';
 import { getRelationshipInfo, sanitizeTableName } from '../schema-helpers.js';
-import type { ForeignKeyDef, ModelSchema, ViewSchema } from '../types/orm-types.js';
+import type { ForeignKeyDef, HypertableConfig, ModelSchema, ViewSchema } from '../types/orm-types.js';
 import ModelProperty from '../model-property.js';
 
 interface ViewSnapshotEntry {
@@ -24,6 +24,7 @@ interface ModelSnapshotEntry {
   columns: Record<string, string>;
   foreignKeys: Record<string, ForeignKeyDef>;
   vectorColumns?: Record<string, number>;
+  hypertable?: HypertableConfig;
 }
 
 interface JoinDef {
@@ -82,6 +83,8 @@ export function introspectModels(): Record<string, ModelSchema> {
       };
     }
 
+    const hypertable = (modelClass as { hypertable?: HypertableConfig }).hypertable;
+
     schemas[name] = {
       table: sanitizeTableName(getPluralName(name)),
       idType,
@@ -89,6 +92,7 @@ export function introspectModels(): Record<string, ModelSchema> {
       foreignKeys,
       relationships,
       vectorColumns,
+      hypertable: hypertable || undefined,
       memory: (modelClass as { memory?: boolean }).memory === true,
     };
   }
@@ -97,13 +101,16 @@ export function introspectModels(): Record<string, ModelSchema> {
 }
 
 export function buildTableDDL(name: string, schema: ModelSchema, allSchemas: Record<string, ModelSchema> = {}): string {
-  const { idType, columns, foreignKeys } = schema;
+  const { idType, columns, foreignKeys, hypertable } = schema;
   const table = sanitizeTableName(schema.table);
   const lines: string[] = [];
+  const useCompositePK = hypertable && idType !== 'string';
 
   // Primary key
   if (idType === 'string') {
     lines.push('  "id" VARCHAR(255) PRIMARY KEY');
+  } else if (useCompositePK) {
+    lines.push('  "id" INTEGER GENERATED ALWAYS AS IDENTITY');
   } else {
     lines.push('  "id" INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY');
   }
@@ -120,13 +127,22 @@ export function buildTableDDL(name: string, schema: ModelSchema, allSchemas: Rec
   }
 
   // Timestamps
-  lines.push('  "created_at" TIMESTAMPTZ DEFAULT NOW()');
+  if (useCompositePK) {
+    lines.push('  "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW()');
+  } else {
+    lines.push('  "created_at" TIMESTAMPTZ DEFAULT NOW()');
+  }
   lines.push('  "updated_at" TIMESTAMPTZ DEFAULT NOW()');
 
   // Foreign key constraints
   for (const [fkCol, fkDef] of Object.entries(foreignKeys)) {
     const refTable = sanitizeTableName(fkDef.references);
     lines.push(`  FOREIGN KEY ("${fkCol}") REFERENCES "${refTable}"("${fkDef.column}") ON DELETE SET NULL`);
+  }
+
+  // Composite primary key for hypertable models
+  if (useCompositePK) {
+    lines.push(`  PRIMARY KEY ("id", "${hypertable.timeColumn}")`);
   }
 
   return `CREATE TABLE IF NOT EXISTS "${table}" (\n${lines.join(',\n')}\n)`;
@@ -336,6 +352,7 @@ export function schemasToSnapshot(schemas: Record<string, ModelSchema>): Record<
       ...(schema.vectorColumns && Object.keys(schema.vectorColumns).length > 0
         ? { vectorColumns: { ...schema.vectorColumns } }
         : {}),
+      ...(schema.hypertable ? { hypertable: schema.hypertable } : {}),
     };
   }
 

--- a/src/types/orm-types.ts
+++ b/src/types/orm-types.ts
@@ -86,6 +86,16 @@ export interface ForeignKeyDef {
   column: string;
 }
 
+export interface HypertableConfig {
+  timeColumn: string;
+  chunkInterval?: string;
+  compress?: {
+    segmentBy?: string;
+    orderBy?: string;
+    after?: string;
+  };
+}
+
 export interface ModelSchema {
   table: string;
   idType: string;
@@ -96,6 +106,7 @@ export interface ModelSchema {
     hasMany: Record<string, string | null>;
   };
   vectorColumns?: Record<string, number>;
+  hypertable?: HypertableConfig;
   memory: boolean;
 }
 
@@ -139,6 +150,7 @@ export interface SnapshotEntry {
   columns?: Record<string, string>;
   foreignKeys?: Record<string, ForeignKeyDef>;
   vectorColumns?: Record<string, number>;
+  hypertable?: HypertableConfig;
   isView?: boolean;
   viewName?: string;
   source?: string;

--- a/test/unit/postgres/schema-introspector-test.js
+++ b/test/unit/postgres/schema-introspector-test.js
@@ -251,4 +251,104 @@ module('[Unit] Postgres Schema Introspector — schemasToSnapshot', function() {
 
     assert.strictEqual(snapshot.author.vectorColumns, undefined, 'no vectorColumns key');
   });
+
+  test('includes hypertable config in snapshot when present', function(assert) {
+    const schemas = {
+      'stat-snapshot': {
+        table: 'stat_snapshots',
+        idType: 'number',
+        columns: { minute: 'INTEGER' },
+        foreignKeys: {},
+        relationships: { belongsTo: {}, hasMany: {} },
+        hypertable: { timeColumn: 'created_at', chunkInterval: '7 days' },
+        memory: false,
+      },
+    };
+
+    const snapshot = schemasToSnapshot(schemas);
+
+    assert.deepEqual(snapshot['stat-snapshot'].hypertable, { timeColumn: 'created_at', chunkInterval: '7 days' }, 'hypertable config included');
+  });
+
+  test('omits hypertable from snapshot when absent', function(assert) {
+    const schemas = numericPkSchemas();
+    const snapshot = schemasToSnapshot(schemas);
+
+    assert.strictEqual(snapshot.author.hypertable, undefined, 'no hypertable key');
+  });
+});
+
+module('[Unit] Postgres Schema Introspector — buildTableDDL hypertable', function() {
+
+  function hypertableSchema() {
+    return {
+      'stat-snapshot': {
+        table: 'stat_snapshots',
+        idType: 'number',
+        columns: { minute: 'INTEGER', possession: 'REAL' },
+        foreignKeys: { match_id: { references: 'matches', column: 'id' } },
+        relationships: { belongsTo: { match: 'match' }, hasMany: {} },
+        hypertable: { timeColumn: 'created_at', chunkInterval: '7 days' },
+        memory: false,
+      },
+      match: {
+        table: 'matches',
+        idType: 'string',
+        columns: { status: 'VARCHAR(255)' },
+        foreignKeys: {},
+        relationships: { belongsTo: {}, hasMany: {} },
+        memory: false,
+      },
+    };
+  }
+
+  test('emits composite PK for hypertable model with numeric id', function(assert) {
+    const schemas = hypertableSchema();
+    const ddl = buildTableDDL('stat-snapshot', schemas['stat-snapshot'], schemas);
+
+    assert.true(ddl.includes('PRIMARY KEY ("id", "created_at")'), 'composite PK present');
+    assert.false(ddl.includes('IDENTITY PRIMARY KEY'), 'no inline PK on id column');
+    assert.true(ddl.includes('"id" INTEGER GENERATED ALWAYS AS IDENTITY'), 'id still uses IDENTITY');
+  });
+
+  test('emits NOT NULL on created_at for hypertable model', function(assert) {
+    const schemas = hypertableSchema();
+    const ddl = buildTableDDL('stat-snapshot', schemas['stat-snapshot'], schemas);
+
+    assert.true(ddl.includes('"created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW()'), 'created_at has NOT NULL');
+  });
+
+  test('non-hypertable model keeps inline PK unchanged', function(assert) {
+    const schemas = hypertableSchema();
+    const ddl = buildTableDDL('match', schemas.match, schemas);
+
+    assert.true(ddl.includes('"id" VARCHAR(255) PRIMARY KEY'), 'inline PK on string id');
+    assert.false(ddl.includes('PRIMARY KEY ("id"'), 'no table-level composite PK');
+    assert.true(ddl.includes('"created_at" TIMESTAMPTZ DEFAULT NOW()'), 'created_at without NOT NULL');
+  });
+
+  test('string PK model with hypertable keeps inline PK (no composite)', function(assert) {
+    const schemas = {
+      event: {
+        table: 'events',
+        idType: 'string',
+        columns: {},
+        foreignKeys: {},
+        relationships: { belongsTo: {}, hasMany: {} },
+        hypertable: { timeColumn: 'created_at' },
+        memory: false,
+      },
+    };
+    const ddl = buildTableDDL('event', schemas.event, schemas);
+
+    assert.true(ddl.includes('"id" VARCHAR(255) PRIMARY KEY'), 'string PK stays inline');
+    assert.false(ddl.includes('PRIMARY KEY ("id", "created_at")'), 'no composite PK for string ids');
+  });
+
+  test('hypertable DDL includes FK constraints', function(assert) {
+    const schemas = hypertableSchema();
+    const ddl = buildTableDDL('stat-snapshot', schemas['stat-snapshot'], schemas);
+
+    assert.true(ddl.includes('FOREIGN KEY ("match_id") REFERENCES "matches"("id") ON DELETE SET NULL'), 'FK constraint present');
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `HypertableConfig` type and extends `ModelSchema`/`SnapshotEntry` to carry hypertable metadata (#91)
- Schema introspector extracts `static hypertable` from model classes and emits composite PK `(id, created_at)` for hypertable-bound models (#92)
- Migration generator appends `create_hypertable()`, compression, and policy DDL when `configKey === 'timescale'` (#93)

Closes #91, closes #92, closes #93.

## How it works

Models declare hypertable config as a static property:
```javascript
static hypertable = {
  timeColumn: 'created_at',
  chunkInterval: '7 days',
  compress: { segmentBy: 'match_id', orderBy: 'created_at', after: '7 days' }
};
```

The migration generator then produces a single migration with:
1. `CREATE TABLE` with composite PK `(id, created_at)` — satisfies TimescaleDB's TS103 constraint
2. `SELECT create_hypertable(...)` — converts table to hypertable
3. `ALTER TABLE SET (timescaledb.compress...)` — enables compression
4. `SELECT add_compression_policy(...)` — adds compression policy

Non-hypertable models are completely unaffected.

## Research basis

All design decisions grounded in Sprint 32 research (abofs/stonyx-orm#90):
- [Track 1: Lifecycle Ownership](https://github.com/abofs/beatrix-shared/blob/main/projects/stonyx/research/ts103-lifecycle-ownership.md)
- [Track 2: Schema Metadata](https://github.com/abofs/beatrix-shared/blob/main/projects/stonyx/research/ts103-schema-metadata.md)
- [Track 3: PK Strategy](https://github.com/abofs/beatrix-shared/blob/main/projects/stonyx/research/ts103-pk-strategy.md)

## Test plan

- [x] 632/632 tests pass (7 new hypertable-specific tests)
- [x] Composite PK emitted only for hypertable models with numeric ids
- [x] `NOT NULL` added to `created_at` for hypertable models
- [x] Non-hypertable models unchanged (inline PK, nullable created_at)
- [x] String PK models with hypertable skip composite PK
- [x] Snapshot persists hypertable config
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)