### PR TITLE
fix: add programmatic CRUD methods for SQL persistence

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,11 @@ export { beforeHook, afterHook, clearHook, clearAllHooks } from './hooks.js'; //
 
 // Store API:
 // store.get(model, id)   -- sync, memory-only
-// store.find(model, id)  -- async, MySQL for memory:false models
+// store.find(model, id)  -- async, SQL for memory:false models
 // store.findAll(model)   -- async, all records
-// store.query(model, conditions) -- async, always hits MySQL
+// store.query(model, conditions) -- async, always hits SQL
+//
+// Programmatic CRUD (memory + SQL persistence):
+// Orm.create(model, data)      -- async, createRecord + sqlDb.persist
+// Orm.update(model, id, data)  -- async, updateRecord + sqlDb.persist
+// Orm.remove(model, id)        -- async, sqlDb.persist + store.remove

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,8 @@ import baseTransforms from './transforms.js';
 import Store from './store.js';
 import Serializer from './serializer.js';
 import { setup } from '@stonyx/events';
+import type { OrmRecord } from './types/orm-types.js';
+import { isOrmRecord } from './utils.js';
 
 interface OrmOptions {
   dbType?: string;
@@ -212,6 +214,63 @@ export default class Orm {
   isView(modelName: string): boolean {
     const modelClassPrefix = kebabCaseToPascalCase(modelName);
     return !!this.views[`${modelClassPrefix}View`];
+  }
+
+  /**
+   * Programmatic create — writes to memory AND persists to SQL database.
+   * Use instead of createRecord() when records must be persisted to PostgreSQL/TimescaleDB.
+   */
+  static async create(modelName: string, data: Record<string, unknown> = {}): Promise<OrmRecord> {
+    if (!Orm.initialized) throw new Error('ORM is not ready');
+
+    const { createRecord } = await import('./manage-record.js');
+    const record = createRecord(modelName, data, { serialize: false }) as unknown as OrmRecord;
+
+    if (Orm.instance.sqlDb) {
+      const response: { data: { id: unknown } } = { data: { id: record.id } };
+      await Orm.instance.sqlDb.persist('create', modelName, {}, response);
+    }
+
+    return record;
+  }
+
+  /**
+   * Programmatic update — updates in memory AND persists to SQL database.
+   * Captures old state for diff-based UPDATE queries.
+   */
+  static async update(modelName: string, id: string | number, data: Record<string, unknown>): Promise<OrmRecord> {
+    if (!Orm.initialized) throw new Error('ORM is not ready');
+
+    const record = Orm.store.get(modelName, id);
+    if (!record || !isOrmRecord(record)) throw new Error(`Record ${modelName}:${id} not found`);
+
+    const oldState = JSON.parse(JSON.stringify(record.__data));
+
+    // Apply attribute updates directly, matching the REST handler pattern
+    for (const [key, value] of Object.entries(data)) {
+      if (key === 'id') continue;
+      record[key] = value;
+    }
+
+    if (Orm.instance.sqlDb) {
+      await Orm.instance.sqlDb.persist('update', modelName, { record, oldState }, {});
+    }
+
+    return record;
+  }
+
+  /**
+   * Programmatic delete — removes from SQL database AND memory store.
+   * SQL delete runs first to ensure consistency on failure.
+   */
+  static async remove(modelName: string, id: string | number): Promise<void> {
+    if (!Orm.initialized) throw new Error('ORM is not ready');
+
+    if (Orm.instance.sqlDb) {
+      await Orm.instance.sqlDb.persist('delete', modelName, { recordId: id }, {});
+    }
+
+    Orm.store.remove(modelName, id);
   }
 
   // Queue warnings to avoid the same error from being logged in the same iteration

--- a/test/unit/programmatic-crud-test.js
+++ b/test/unit/programmatic-crud-test.js
@@ -1,0 +1,140 @@
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import Orm, { createRecord, store } from '@stonyx/orm';
+
+const { module, test } = QUnit;
+
+module('[Unit] Programmatic CRUD | Orm.create / Orm.update / Orm.remove', function(hooks) {
+  let originalSqlDb;
+  let originalInitialized;
+
+  hooks.beforeEach(function() {
+    originalSqlDb = Orm.instance?.sqlDb;
+    originalInitialized = Orm.initialized;
+  });
+
+  hooks.afterEach(function() {
+    if (Orm.instance) Orm.instance.sqlDb = originalSqlDb;
+    Orm.initialized = originalInitialized;
+    store.get('owner')?.clear();
+    sinon.restore();
+  });
+
+  module('Orm.create', function() {
+    test('creates record in memory and calls sqlDb.persist', async function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      const record = await Orm.create('owner', { id: 'test-1', gender: 'female' });
+
+      assert.strictEqual(record.id, 'test-1', 'record has correct id');
+      assert.ok(persistStub.calledOnce, 'sqlDb.persist was called');
+      assert.strictEqual(persistStub.firstCall.args[0], 'create', 'persist called with create operation');
+      assert.strictEqual(persistStub.firstCall.args[1], 'owner', 'persist called with model name');
+      assert.strictEqual(persistStub.firstCall.args[3].data.id, 'test-1', 'persist response contains record id');
+    });
+
+    test('creates record without SQL when sqlDb is not configured', async function(assert) {
+      Orm.initialized = true;
+      Orm.instance.sqlDb = undefined;
+
+      const record = await Orm.create('owner', { id: 'no-sql', gender: 'male' });
+
+      assert.strictEqual(record.id, 'no-sql', 'record created in memory');
+      assert.ok(store.get('owner').has('no-sql'), 'record exists in store');
+    });
+
+    test('throws when ORM is not initialized', async function(assert) {
+      Orm.initialized = false;
+
+      await assert.rejects(
+        Orm.create('owner', { id: 'fail', gender: 'fail' }),
+        /ORM is not ready/,
+        'throws ORM not ready error'
+      );
+    });
+  });
+
+  module('Orm.update', function() {
+    test('updates record and calls sqlDb.persist with old state', async function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      createRecord('owner', { id: 'upd-1', gender: 'female', age: 25 }, { serialize: false });
+
+      const record = await Orm.update('owner', 'upd-1', { gender: 'male', age: 30 });
+
+      assert.strictEqual(record.gender, 'male', 'record gender was updated');
+      assert.strictEqual(record.age, 30, 'record age was updated');
+      assert.ok(persistStub.calledOnce, 'sqlDb.persist was called');
+      assert.strictEqual(persistStub.firstCall.args[0], 'update', 'persist called with update operation');
+      assert.strictEqual(persistStub.firstCall.args[1], 'owner', 'persist called with model name');
+
+      const context = persistStub.firstCall.args[2];
+      assert.strictEqual(context.oldState.gender, 'female', 'old state captured before update');
+      assert.strictEqual(context.oldState.age, 25, 'old age captured');
+    });
+
+    test('throws when record does not exist', async function(assert) {
+      Orm.initialized = true;
+      Orm.instance.sqlDb = undefined;
+
+      await assert.rejects(
+        Orm.update('owner', 'nonexistent', { gender: 'fail' }),
+        /not found/,
+        'throws record not found error'
+      );
+    });
+
+    test('throws when ORM is not initialized', async function(assert) {
+      Orm.initialized = false;
+
+      await assert.rejects(
+        Orm.update('owner', 'fail', { gender: 'fail' }),
+        /ORM is not ready/,
+        'throws ORM not ready error'
+      );
+    });
+  });
+
+  module('Orm.remove', function() {
+    test('calls sqlDb.persist with delete operation then removes from store', async function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      createRecord('owner', { id: 'del-1', gender: 'female' }, { serialize: false });
+      assert.ok(store.get('owner').has('del-1'), 'record exists before remove');
+
+      await Orm.remove('owner', 'del-1');
+
+      assert.ok(persistStub.calledOnce, 'sqlDb.persist was called');
+      assert.strictEqual(persistStub.firstCall.args[0], 'delete', 'persist called with delete operation');
+      assert.strictEqual(persistStub.firstCall.args[2].recordId, 'del-1', 'persist context contains record id');
+      assert.notOk(store.get('owner').has('del-1'), 'record removed from store');
+    });
+
+    test('removes from store without SQL when sqlDb is not configured', async function(assert) {
+      Orm.initialized = true;
+      Orm.instance.sqlDb = undefined;
+
+      createRecord('owner', { id: 'del-nosql', gender: 'male' }, { serialize: false });
+
+      await Orm.remove('owner', 'del-nosql');
+
+      assert.notOk(store.get('owner').has('del-nosql'), 'record removed from store');
+    });
+
+    test('throws when ORM is not initialized', async function(assert) {
+      Orm.initialized = false;
+
+      await assert.rejects(
+        Orm.remove('owner', 'fail'),
+        /ORM is not ready/,
+        'throws ORM not ready error'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `Orm.create(model, data)`, `Orm.update(model, id, data)`, and `Orm.remove(model, id)` static methods
- These wrap `createRecord()` + `sqlDb.persist()` so programmatic callers get the same memory + SQL persistence as the REST pipeline
- Unblocks nextgoal-data-collector#19 which calls `createRecord()` directly and needs SQL persistence

Fixes #96

## Test plan

- [x] 9 new unit tests covering create/update/remove with and without sqlDb, plus initialization guards
- [x] All 641 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)