### PR TITLE
docs: add project-level SME agent templates

### DIFF
--- a/docs/agents/architect.md
+++ b/docs/agents/architect.md
@@ -1,0 +1,43 @@
+# SME Template: Architect — Stonyx ORM
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/architect.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-orm`
+**Framework:** Data persistence layer for the Stonyx ecosystem
+**Domain:** ORM with model definitions, relationships (hasMany/belongsTo), serializers, transforms, lifecycle hooks, aggregate helpers, views, and multi-backend persistence (JSON file, MySQL, PostgreSQL, TimescaleDB)
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (ES Modules) |
+| Runtime | Node.js |
+| Framework | Stonyx (auto-discovered as `@stonyx/orm` module) |
+| Database Adapters | JSON file (single/directory mode), MySQL (`mysql2`), PostgreSQL (`pg`), TimescaleDB |
+| Events | `@stonyx/events` (pub/sub for hook system) |
+| Scheduling | `@stonyx/cron` (auto-save intervals) |
+| REST Integration | `@stonyx/rest-server` (optional peer dependency for auto-route registration) |
+| Testing | QUnit + Sinon, with optional MySQL/PostgreSQL integration tests |
+
+## Architecture Patterns
+
+- **Singleton ORM with in-memory store:** `Orm` class enforces single instance; `Store` holds all records in nested `Map<modelName, Map<id, record>>` — SQL-backed models can optionally skip memory caching via `memory: false` flag
+- **Proxy-based record access:** Records use ES `Proxy` to intercept property reads/writes, routing through transforms and change tracking — direct `__data` access bypasses this and is forbidden in consumer code
+- **Auto-discovery pipeline:** Models, serializers, transforms, and access classes are loaded from configured directory paths via `forEachFileImport` with recursive scanning and kebab-to-PascalCase naming convention
+- **Dual persistence path:** REST API operations go through `orm-request.ts` (hooks + store + optional SQL persist); programmatic operations use `Orm.create()` / `Orm.update()` / `Orm.remove()` static methods
+- **Middleware hook system:** Events follow `{timing}:{operation}:{modelName}` naming (e.g., `before:create:animal`); before hooks can halt operations by returning a status code or response object
+- **SQL adapter abstraction:** MySQL, PostgreSQL, and TimescaleDB each implement the `SqlDb` interface (`init`, `startup`, `shutdown`, `persist`, `findRecord`, `findAll`) with adapter-specific query builders, migration generators, and schema introspectors
+- **View layer:** Read-only computed models resolved via `ViewResolver` that compose data from other models without direct database tables
+- **Relationship registry:** Global maps track `hasMany`, `belongsTo`, `pending`, and `pendingBelongsTo` relationships; records are wired after creation, with cascading unload for cleanup
+
+## Live Knowledge
+
+- The store has two read paths: `get()` (sync, memory-only) and `find()` / `findAll()` (async, hits SQL for `memory: false` models) — using the wrong one causes silent data staleness
+- JSON file mode supports two storage layouts: single `db.json` file or directory mode with one `{collection}.json` per model — migration commands (`db:migrate-to-directory`, `db:migrate-to-file`) handle conversion
+- The `pluralName` static override on models affects REST route paths, JSON:API type references, AND database table names — a mismatch causes 404s or table-not-found errors
+- `oldState` in hooks is captured via `JSON.parse(JSON.stringify())` deep copy before the operation — this means non-serializable values (functions, circular refs) are silently dropped
+- The module waits for `@stonyx/rest-server` via `waitForModule('rest-server')` before mounting routes — if rest-server is not in `devDependencies`, the ORM still works but REST integration is silently skipped
+- PostgreSQL and TimescaleDB adapters share connection and migration infrastructure but TimescaleDB adds hypertable creation and time-partitioned query building

--- a/docs/agents/qa-test-engineer.md
+++ b/docs/agents/qa-test-engineer.md
@@ -1,0 +1,39 @@
+# SME Template: QA Test Engineer — Stonyx ORM
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/qa-test-engineer.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-orm`
+**Framework:** Data persistence layer for the Stonyx ecosystem
+**Domain:** ORM with model definitions, relationships, serializers, hooks, aggregate helpers, views, and multi-backend persistence
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Test Runner | QUnit (via `stonyx test`) |
+| Mocking | Sinon |
+| Build (tests) | `tsc -p tsconfig.test.json` (outputs to `dist-test/`) |
+| Test Command | `npm run build && npm run build:test && stonyx test 'dist-test/test/**/*-test.js'` |
+| Test Fixtures | `test/sample/` directory with sample models, serializers, transforms, access classes |
+| Test Config | `test/config/environment.js` with overrides for file paths and DB settings |
+| Integration DB | MySQL (optional, via `scripts/setup-test-db.sh` — creates `stonyx_orm_test` database) |
+
+## Architecture Patterns
+
+- **Three test tiers:** `test/unit/` for isolated logic, `test/integration/` for full ORM lifecycle with REST server, `test/helpers/` for shared test utilities
+- **Sample fixtures:** `test/sample/` contains real model, serializer, transform, and access class files that the ORM discovers during integration tests — changes here affect test behavior
+- **Singleton cleanup:** Tests must call `clearAllHooks()` in teardown and reset `Orm.instance`, `Store.instance`, and relationship registries between test runs to prevent state leakage
+- **Optional MySQL tests:** Integration tests that require MySQL check availability at runtime; they skip gracefully in CI (`CI=true`) when MySQL is not present
+
+## Live Knowledge
+
+- The `store` singleton (`Store.instance`) persists across tests — always reset it in `afterEach` or use the helper cleanup functions to avoid false positives from cached records
+- Hook tests should verify both the halting path (before hook returns a value) and the pass-through path (returns `undefined`) — the distinction between `return undefined` and no return statement matters
+- Relationship wiring tests need to create records in the correct order: parent records must exist in the store before child records reference them via `belongsTo` — out-of-order creation triggers the pending relationship queue
+- `createRecord` and `updateRecord` are the programmatic entry points; `Orm.create()` / `Orm.update()` / `Orm.remove()` add SQL persistence on top — test both paths separately
+- The proxy-based record access means `record.age` and `record.__data.age` can diverge if transforms are involved — test assertions should always use the proxy interface
+- View resolver tests need both source models populated in the store and view definitions registered — views are read-only, so `store.remove()` on a view model name should throw
+- Auto-save tests (`DB_AUTO_SAVE: 'onUpdate'`) need to verify that file writes happen after each mutation and that `DB_AUTO_SAVE: 'true'` uses the cron interval instead

--- a/docs/agents/security-reviewer.md
+++ b/docs/agents/security-reviewer.md
@@ -1,0 +1,36 @@
+# SME Template: Security Reviewer — Stonyx ORM
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/security-reviewer.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-orm`
+**Framework:** Data persistence layer for the Stonyx ecosystem
+**Domain:** ORM handling data storage, retrieval, and mutation across JSON file, MySQL, PostgreSQL, and TimescaleDB backends — with REST API auto-registration and access control
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (ES Modules) |
+| Database Adapters | JSON file, MySQL (`mysql2`), PostgreSQL (`pg`), TimescaleDB |
+| REST Integration | `@stonyx/rest-server` (Express-based, optional peer dependency) |
+| Auth Model | Access classes with per-model `access(request)` methods |
+
+## Architecture Patterns
+
+- **Access class authorization:** Access classes define which models are exposed and return allowed operations (`['read', 'create', 'update', 'delete']`) or `false` per request — this is the primary authorization gate for REST endpoints
+- **Before-hook halting:** `beforeHook` middleware can return HTTP status codes (e.g., 400, 403) to block operations before they reach the store or database — this is the secondary validation layer
+- **SQL query parameterization:** MySQL, PostgreSQL, and TimescaleDB adapters use parameterized queries via their respective drivers (`mysql2`, `pg`) — review query builders for injection vectors
+- **JSON file persistence:** In file/directory mode, data is written directly to disk as JSON — no encryption, no access control beyond filesystem permissions
+
+## Live Knowledge
+
+- Access classes receive the raw Express `request` object — any authorization logic that reads headers, cookies, or tokens runs in this layer and must validate inputs defensively
+- The `include` query parameter for relationship sideloading traverses relationships recursively — unbounded `include` depth could expose more data than intended or cause performance issues
+- The `__data` / `__relationships` internals on records are accessible via the proxy but marked as private — consumer code that bypasses the proxy can skip transforms and write arbitrary values
+- SQL migration generation compares model schemas against database state — the generated SQL runs with the configured database user's permissions, so privilege escalation depends on the DB user's grants
+- `DB_AUTO_SAVE` in `onUpdate` mode writes to disk after every REST mutation — high write volumes can cause filesystem contention; `DB_FILE` / `DB_DIRECTORY` paths are taken from config without path traversal validation
+- The `body` property in hook context (`context.body.data.attributes`) comes directly from the parsed JSON request body — hooks that read these values must treat them as untrusted input
+- Connection credentials for MySQL/PostgreSQL are read from environment variables and passed to driver constructors — ensure these are not logged or exposed in error messages

--- a/docs/agents/validation-loop-team.md
+++ b/docs/agents/validation-loop-team.md
@@ -1,0 +1,36 @@
+# SME Template: Validation Loop Team — Stonyx ORM
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/validation-loop-team.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx-orm`
+**Framework:** Data persistence layer for the Stonyx ecosystem
+**Domain:** ORM covering models, relationships, serialization, hooks, views, aggregates, and persistence across JSON file, MySQL, PostgreSQL, and TimescaleDB
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (ES Modules) |
+| Runtime | Node.js |
+| Testing | QUnit + Sinon |
+| CI | GitHub Actions (`ci.yml`) |
+| Database Adapters | JSON file, MySQL, PostgreSQL, TimescaleDB |
+
+## Architecture Patterns
+
+- **Multi-backend persistence with shared interface:** All SQL adapters implement `SqlDb` (`init`, `startup`, `shutdown`, `persist`, `findRecord`, `findAll`) — changes to this interface require validation across MySQL, PostgreSQL, and TimescaleDB adapters
+- **Two record creation paths:** REST-originated records go through `orm-request.ts` (with hooks and access control); programmatic records use `Orm.create()` / `Orm.update()` / `Orm.remove()` — both must produce identical store and database states
+- **Event-driven hooks:** Hook events are registered via `@stonyx/events` setup during `init()` — the event name list is derived from discovered models, so adding a new model automatically creates its hook events
+- **Store dual-read API:** Sync `store.get()` for memory-cached models, async `store.find()` / `store.findAll()` for SQL-backed models — the `_memoryResolver` callback determines which path is used
+
+## Live Knowledge
+
+- Relationship cascading on unload is order-sensitive: `hasMany` arrays are spliced, `belongsTo` references are nullified, then registry entries are cleaned — validation must cover all three cleanup phases, especially for bidirectional relationships
+- The `plural-registry.ts` maps model names to their plural forms for REST routes and DB table names — `pluralize()` from `@stonyx/utils` handles most cases, but models with irregular plurals need `static pluralName` — missing overrides cause silent route/table mismatches
+- Migration drift detection compares model attribute definitions against live database schemas — the schema introspectors for MySQL and PostgreSQL handle type mapping differently (e.g., `attr('number')` maps to `INT` in MySQL but `INTEGER` in PostgreSQL)
+- The `include` parameter for relationship sideloading supports arbitrary nesting depth (`owner.pets.traits`) with deduplication by type+id — deep nesting with circular relationships must terminate without infinite recursion
+- Published package includes both `dist/` and `src/` (per `files` in package.json) — validate that TypeScript source files don't contain debug code or test-only imports
+- `Orm.ready` is assigned from `Promise.all(promises)` in `init()` — if any sub-initialization (DB, rest-server setup, model loading) fails, the entire ORM init rejects, but partial state may already exist in the store


### PR DESCRIPTION
## Summary
- Add `docs/agents/` directory with SME templates for architect, security-reviewer, qa-test-engineer, and validation-loop-team roles
- Templates provide ORM-specific context overlays (multi-backend persistence, relationship management, hook system, store dual-read API, SQL adapter architecture) that layer on top of beatrix-shared base templates
- Content derived from actual source analysis of `main.ts`, `index.ts`, `store.ts`, `hooks.ts`, and database adapter directories

## Test plan
- [ ] Verify each template follows the exact format: title, inherits-from block, project context, tech stack table, architecture patterns, live knowledge
- [ ] Confirm architecture patterns reference actual Store API methods (get/find/findAll/query), hook event naming convention, and SQL adapter interface
- [ ] Check that security-reviewer template correctly identifies access class authorization, SQL parameterization, and data exposure concerns

🤖 Generated with [Claude Code](https://claude.com/claude-code)