### PR TITLE
fix: resolve belongsTo FK values from raw string IDs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -228,7 +228,7 @@ export default class Orm {
 
     if (Orm.instance.sqlDb) {
       const response: { data: { id: unknown } } = { data: { id: record.id } };
-      await Orm.instance.sqlDb.persist('create', modelName, {}, response);
+      await Orm.instance.sqlDb.persist('create', modelName, { rawData: data }, response);
     }
 
     return record;

--- a/src/postgres/postgres-db.ts
+++ b/src/postgres/postgres-db.ts
@@ -19,6 +19,7 @@ interface PersistContext {
   record?: OrmRecord;
   recordId?: unknown;
   oldState?: Record<string, unknown>;
+  rawData?: Record<string, unknown>;
 }
 
 interface PersistResponse {
@@ -477,7 +478,7 @@ export default class PostgresDB {
     }
   }
 
-  private async _persistCreate(modelName: string, _context: PersistContext, response: PersistResponse): Promise<void> {
+  private async _persistCreate(modelName: string, context: PersistContext, response: PersistResponse): Promise<void> {
     const schemas = this.deps.introspectModels();
     const schema = schemas[modelName];
 
@@ -491,7 +492,7 @@ export default class PostgresDB {
 
     if (!record) return;
 
-    const insertData = this._recordToRow(record, schema);
+    const insertData = this._recordToRow(record, schema, context.rawData);
 
     // For auto-increment models, remove the pending ID
     const isPendingId = record.__data.__pendingSqlId;
@@ -549,7 +550,10 @@ export default class PostgresDB {
     // Check FK changes too
     for (const fkCol of Object.keys(schema.foreignKeys)) {
       const relName = fkCol.replace(/_id$/, '');
-      const currentFkValue = (record.__relationships[relName] as { id: unknown } | undefined)?.id ?? null;
+      const relValue = record.__relationships[relName];
+      const currentFkValue = (relValue && typeof relValue === 'object' && relValue !== null)
+        ? (relValue as { id: unknown }).id ?? null
+        : relValue ?? record.__data[relName] ?? null;
       const oldFkValue = oldState[relName] ?? null;
 
       if (currentFkValue !== oldFkValue) {
@@ -579,7 +583,7 @@ export default class PostgresDB {
     await this.requirePool().query(sql, values);
   }
 
-  private _recordToRow(record: OrmRecord, schema: ModelSchema): Record<string, unknown> {
+  private _recordToRow(record: OrmRecord, schema: ModelSchema, rawData?: Record<string, unknown>): Record<string, unknown> {
     const row: Record<string, unknown> = {};
     const data = record.__data;
 
@@ -603,11 +607,16 @@ export default class PostgresDB {
       const relName = fkCol.replace(/_id$/, '');
       const related = record.__relationships[relName];
 
-      if (related) {
+      if (related && typeof related === 'object' && related !== null) {
         row[fkCol] = (related as { id: unknown }).id;
+      } else if (related != null) {
+        // Raw FK value (e.g., string ID stored directly in __relationships)
+        row[fkCol] = related;
       } else if (data[relName] !== undefined) {
-        // Raw FK value (e.g., from create payload)
         row[fkCol] = data[relName];
+      } else if (rawData?.[relName] !== undefined) {
+        // Fallback to original create payload for unresolved belongsTo FKs
+        row[fkCol] = rawData[relName];
       }
     }
 

--- a/test/unit/fk-resolution-test.js
+++ b/test/unit/fk-resolution-test.js
@@ -1,0 +1,57 @@
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import Orm, { createRecord, store } from '@stonyx/orm';
+
+const { module, test } = QUnit;
+
+module('[Unit] FK Resolution | belongsTo raw string FK values', function(hooks) {
+  let originalSqlDb;
+  let originalInitialized;
+
+  hooks.beforeEach(function() {
+    originalSqlDb = Orm.instance?.sqlDb;
+    originalInitialized = Orm.initialized;
+  });
+
+  hooks.afterEach(function() {
+    if (Orm.instance) Orm.instance.sqlDb = originalSqlDb;
+    Orm.initialized = originalInitialized;
+    store.get('owner')?.clear();
+    store.get('animal')?.clear();
+    sinon.restore();
+  });
+
+  test('Orm.create passes rawData through context for FK resolution', async function(assert) {
+    const persistStub = sinon.stub().resolves();
+    Orm.initialized = true;
+    Orm.instance.sqlDb = { persist: persistStub };
+
+    await Orm.create('animal', { id: 'fk-test-1', type: 'dog', age: 3, size: 'large', owner: 'unresolved-owner-id' });
+
+    assert.ok(persistStub.calledOnce, 'sqlDb.persist was called');
+    assert.strictEqual(persistStub.firstCall.args[0], 'create', 'persist called with create operation');
+
+    const context = persistStub.firstCall.args[2];
+    assert.ok(context.rawData, 'context includes rawData');
+    assert.strictEqual(context.rawData.owner, 'unresolved-owner-id', 'rawData preserves the raw FK value');
+  });
+
+  test('belongsTo with unresolved target sets __relationships to null', function(assert) {
+    // Create animal with FK to owner that does NOT exist in store
+    const animal = createRecord('animal', { id: 'fk-test-2', type: 'cat', age: 2, size: 'small', owner: 'nonexistent-owner' }, { serialize: false });
+
+    assert.strictEqual(animal.__relationships.owner, null, '__relationships is null for unresolved belongsTo');
+  });
+
+  test('belongsTo with resolved target sets __relationships to record object', function(assert) {
+    // Create owner first so it exists in store
+    createRecord('owner', { id: 'resolved-owner', gender: 'female', age: 25 }, { serialize: false });
+
+    const animal = createRecord('animal', { id: 'fk-test-3', type: 'dog', age: 5, size: 'large', owner: 'resolved-owner' }, { serialize: false });
+
+    const related = animal.__relationships.owner;
+    assert.strictEqual(typeof related, 'object', '__relationships is an object for resolved belongsTo');
+    assert.notStrictEqual(related, null, '__relationships is not null');
+    assert.strictEqual(related?.id, 'resolved-owner', 'related record has correct id');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `_recordToRow()` FK resolution when `belongsTo` target record is not in the store
- Pass original `rawData` from `Orm.create()` through persist context as FK fallback
- Fix `_persistUpdate()` FK diff to check `__data` when `__relationships` is null
- Add 3 unit tests for FK resolution with raw string IDs

## Root Cause

When `Orm.create('model', { match: 'some-id' })` is called and the target record doesn't exist in the store, `belongsTo` registers as pending and returns `null`. Both `__relationships['match']` (null) and `__data['match']` (undefined) lose the FK value, so `_recordToRow()` produces a row with no FK column.

## Fix

Thread the original `data` object through `PersistContext.rawData` → `_persistCreate` → `_recordToRow` as a last-resort fallback for FK values. Also fix the `_persistUpdate` FK diff to check `record.__data[relName]` when `__relationships` is null.

## Test plan

- [x] 3 new unit tests for raw string FK resolution (644 total, 0 failures)
- [x] 4 existing MySQL FK resolution integration tests still pass
- [x] 9 existing programmatic CRUD tests still pass
- [x] Full suite: 644 pass, 0 skip, 0 fail

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)