### PR TITLE
fix: move SQL persistence to data layer — auto-persist in createRecord/updateRecord

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export { beforeHook, afterHook, clearHook, clearAllHooks } from './hooks.js'; //
 // store.findAll(model)   -- async, all records
 // store.query(model, conditions) -- async, always hits SQL
 //
-// Programmatic CRUD (memory + SQL persistence):
-// Orm.create(model, data)      -- async, createRecord + sqlDb.persist
-// Orm.update(model, id, data)  -- async, updateRecord + sqlDb.persist
-// Orm.remove(model, id)        -- async, sqlDb.persist + store.remove
+// Data-layer auto-persist (memory + SQL persistence):
+// createRecord(model, data)  -- sync, auto-persists to SQL (fire-and-forget)
+// updateRecord(record, data) -- sync, auto-persists to SQL (fire-and-forget)
+// store.remove(model, id)    -- sync, auto-persists delete to SQL (fire-and-forget)

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,8 +25,6 @@ import baseTransforms from './transforms.js';
 import Store from './store.js';
 import Serializer from './serializer.js';
 import { setup } from '@stonyx/events';
-import type { OrmRecord } from './types/orm-types.js';
-import { isOrmRecord } from './utils.js';
 
 interface OrmOptions {
   dbType?: string;
@@ -214,63 +212,6 @@ export default class Orm {
   isView(modelName: string): boolean {
     const modelClassPrefix = kebabCaseToPascalCase(modelName);
     return !!this.views[`${modelClassPrefix}View`];
-  }
-
-  /**
-   * Programmatic create — writes to memory AND persists to SQL database.
-   * Use instead of createRecord() when records must be persisted to PostgreSQL/TimescaleDB.
-   */
-  static async create(modelName: string, data: Record<string, unknown> = {}): Promise<OrmRecord> {
-    if (!Orm.initialized) throw new Error('ORM is not ready');
-
-    const { createRecord } = await import('./manage-record.js');
-    const record = createRecord(modelName, data, { serialize: false }) as unknown as OrmRecord;
-
-    if (Orm.instance.sqlDb) {
-      const response: { data: { id: unknown } } = { data: { id: record.id } };
-      await Orm.instance.sqlDb.persist('create', modelName, { rawData: data }, response);
-    }
-
-    return record;
-  }
-
-  /**
-   * Programmatic update — updates in memory AND persists to SQL database.
-   * Captures old state for diff-based UPDATE queries.
-   */
-  static async update(modelName: string, id: string | number, data: Record<string, unknown>): Promise<OrmRecord> {
-    if (!Orm.initialized) throw new Error('ORM is not ready');
-
-    const record = Orm.store.get(modelName, id);
-    if (!record || !isOrmRecord(record)) throw new Error(`Record ${modelName}:${id} not found`);
-
-    const oldState = JSON.parse(JSON.stringify(record.__data));
-
-    // Apply attribute updates directly, matching the REST handler pattern
-    for (const [key, value] of Object.entries(data)) {
-      if (key === 'id') continue;
-      record[key] = value;
-    }
-
-    if (Orm.instance.sqlDb) {
-      await Orm.instance.sqlDb.persist('update', modelName, { record, oldState }, {});
-    }
-
-    return record;
-  }
-
-  /**
-   * Programmatic delete — removes from SQL database AND memory store.
-   * SQL delete runs first to ensure consistency on failure.
-   */
-  static async remove(modelName: string, id: string | number): Promise<void> {
-    if (!Orm.initialized) throw new Error('ORM is not ready');
-
-    if (Orm.instance.sqlDb) {
-      await Orm.instance.sqlDb.persist('delete', modelName, { recordId: id }, {});
-    }
-
-    Orm.store.remove(modelName, id);
   }
 
   // Queue warnings to avoid the same error from being logged in the same iteration

--- a/src/manage-record.ts
+++ b/src/manage-record.ts
@@ -3,12 +3,14 @@ import OrmRecord from './record.js';
 import { getGlobalRegistry, getPendingRegistry, getPendingBelongsToRegistry, getBelongsToRegistry, getHasManyRegistry } from './relationships.js';
 import type Serializer from './serializer.js';
 import { isOrmRecord } from './utils.js';
+import log from 'stonyx/log';
 
 interface CreateRecordOptions {
   isDbRecord?: boolean;
   serialize?: boolean;
   transform?: boolean;
   update?: boolean;
+  _skipAutoPersist?: boolean;
   [key: string]: unknown;
 }
 
@@ -111,6 +113,15 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
     pendingBelongsTo.length = 0;
   }
 
+  // Auto-persist to SQL — skip for DB loads (isDbRecord) and relationship resolution (_relationshipKey)
+  const shouldPersist = orm?.sqlDb && !options.isDbRecord && !userOptions._relationshipKey && !options._skipAutoPersist;
+  if (shouldPersist) {
+    const response = { data: { id: record.id } };
+    orm!.sqlDb!.persist('create', modelName, { rawData }, response).catch((err: unknown) => {
+      log.error?.(`[ORM] Failed to persist create for ${modelName}:${String(record.id)}`, err);
+    });
+  }
+
   return record;
 }
 
@@ -125,7 +136,19 @@ export function updateRecord(record: OrmRecord, rawData: unknown, userOptions: C
 
   const options = { ...defaultOptions, ...userOptions, update: true };
 
+  // Capture old state before update for SQL diff
+  const oldState = record.__data ? JSON.parse(JSON.stringify(record.__data)) : {};
+
   record.serialize(rawData, options);
+
+  // Auto-persist to SQL — skip for DB loads (isDbRecord) and relationship resolution (_relationshipKey)
+  const orm = Orm.instance;
+  const shouldPersist = orm?.sqlDb && !options.isDbRecord && !userOptions._relationshipKey && !options._skipAutoPersist;
+  if (shouldPersist && modelName) {
+    orm!.sqlDb!.persist('update', modelName, { record, oldState }, {}).catch((err: unknown) => {
+      log.error?.(`[ORM] Failed to persist update for ${modelName}:${String(record.id)}`, err);
+    });
+  }
 }
 
 /**

--- a/src/orm-request.ts
+++ b/src/orm-request.ts
@@ -330,7 +330,7 @@ export default class OrmRequest extends Request {
       }
 
       const recordAttributes = id !== undefined ? { id, ...sanitizedAttributes } : sanitizedAttributes;
-      const created = createRecord(model, recordAttributes as { [key: string]: unknown }, { serialize: false });
+      const created = createRecord(model, recordAttributes as { [key: string]: unknown }, { serialize: false, _skipAutoPersist: true });
       const record = isOrmRecord(created) ? created : null;
       if (!record) return 500;
 
@@ -368,7 +368,7 @@ export default class OrmRequest extends Request {
           }
         }
         if (Object.keys(relUpdates).length > 0) {
-          updateRecord(record as never, relUpdates);
+          updateRecord(record as never, relUpdates, { _skipAutoPersist: true });
         }
       }
 
@@ -443,9 +443,9 @@ export default class OrmRequest extends Request {
       // Execute main handler
       const response = await handler(request, state);
 
-      // Persist to SQL database for write operations
+      // Persist to SQL database for create/update (delete is handled by store.remove auto-persist)
       const sqlDb = Orm.instance.sqlDb;
-      if (sqlDb && WRITE_OPERATIONS.has(operation)) {
+      if (sqlDb && (operation === 'create' || operation === 'update')) {
         await sqlDb.persist(operation, this.model, context, response);
       }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -176,6 +176,13 @@ export default class Store {
       throw new Error(`Cannot remove records from read-only view '${key}'`);
     }
 
+    // Auto-persist delete to SQL
+    if (id && Orm.instance?.sqlDb) {
+      Orm.instance.sqlDb.persist('delete', key, { recordId: id }, {}).catch((err: unknown) => {
+        console.error(`[ORM] Failed to persist delete for ${key}:${id}`, err);
+      });
+    }
+
     if (id) return this.unloadRecord(key, id);
 
     this.unloadAllRecords(key);

--- a/test/unit/fk-resolution-test.js
+++ b/test/unit/fk-resolution-test.js
@@ -21,12 +21,12 @@ module('[Unit] FK Resolution | belongsTo raw string FK values', function(hooks) 
     sinon.restore();
   });
 
-  test('Orm.create passes rawData through context for FK resolution', async function(assert) {
+  test('createRecord passes rawData through context to sqlDb.persist for FK resolution', function(assert) {
     const persistStub = sinon.stub().resolves();
     Orm.initialized = true;
     Orm.instance.sqlDb = { persist: persistStub };
 
-    await Orm.create('animal', { id: 'fk-test-1', type: 'dog', age: 3, size: 'large', owner: 'unresolved-owner-id' });
+    createRecord('animal', { id: 'fk-test-1', type: 'dog', age: 3, size: 'large', owner: 'unresolved-owner-id' }, { serialize: false });
 
     assert.ok(persistStub.calledOnce, 'sqlDb.persist was called');
     assert.strictEqual(persistStub.firstCall.args[0], 'create', 'persist called with create operation');

--- a/test/unit/programmatic-crud-test.js
+++ b/test/unit/programmatic-crud-test.js
@@ -1,10 +1,10 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import Orm, { createRecord, store } from '@stonyx/orm';
+import Orm, { createRecord, updateRecord, store } from '@stonyx/orm';
 
 const { module, test } = QUnit;
 
-module('[Unit] Programmatic CRUD | Orm.create / Orm.update / Orm.remove', function(hooks) {
+module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.remove', function(hooks) {
   let originalSqlDb;
   let originalInitialized;
 
@@ -20,54 +20,74 @@ module('[Unit] Programmatic CRUD | Orm.create / Orm.update / Orm.remove', functi
     sinon.restore();
   });
 
-  module('Orm.create', function() {
-    test('creates record in memory and calls sqlDb.persist', async function(assert) {
+  module('createRecord auto-persist', function() {
+    test('calls sqlDb.persist with create when sqlDb is configured', function(assert) {
       const persistStub = sinon.stub().resolves();
       Orm.initialized = true;
       Orm.instance.sqlDb = { persist: persistStub };
 
-      const record = await Orm.create('owner', { id: 'test-1', gender: 'female' });
+      const record = createRecord('owner', { id: 'test-1', gender: 'female' }, { serialize: false });
 
       assert.strictEqual(record.id, 'test-1', 'record has correct id');
       assert.ok(persistStub.calledOnce, 'sqlDb.persist was called');
       assert.strictEqual(persistStub.firstCall.args[0], 'create', 'persist called with create operation');
       assert.strictEqual(persistStub.firstCall.args[1], 'owner', 'persist called with model name');
+      assert.deepEqual(persistStub.firstCall.args[2].rawData, { id: 'test-1', gender: 'female' }, 'persist context contains rawData');
       assert.strictEqual(persistStub.firstCall.args[3].data.id, 'test-1', 'persist response contains record id');
     });
 
-    test('creates record without SQL when sqlDb is not configured', async function(assert) {
-      Orm.initialized = true;
-      Orm.instance.sqlDb = undefined;
-
-      const record = await Orm.create('owner', { id: 'no-sql', gender: 'male' });
-
-      assert.strictEqual(record.id, 'no-sql', 'record created in memory');
-      assert.ok(store.get('owner').has('no-sql'), 'record exists in store');
-    });
-
-    test('throws when ORM is not initialized', async function(assert) {
-      Orm.initialized = false;
-
-      await assert.rejects(
-        Orm.create('owner', { id: 'fail', gender: 'fail' }),
-        /ORM is not ready/,
-        'throws ORM not ready error'
-      );
-    });
-  });
-
-  module('Orm.update', function() {
-    test('updates record and calls sqlDb.persist with old state', async function(assert) {
+    test('does NOT call persist when isDbRecord is true', function(assert) {
       const persistStub = sinon.stub().resolves();
       Orm.initialized = true;
       Orm.instance.sqlDb = { persist: persistStub };
 
-      createRecord('owner', { id: 'upd-1', gender: 'female', age: 25 }, { serialize: false });
+      createRecord('owner', { id: 'db-1', gender: 'male' }, { serialize: false, isDbRecord: true });
 
-      const record = await Orm.update('owner', 'upd-1', { gender: 'male', age: 30 });
+      assert.ok(persistStub.notCalled, 'sqlDb.persist was NOT called for DB load');
+    });
 
-      assert.strictEqual(record.gender, 'male', 'record gender was updated');
-      assert.strictEqual(record.age, 30, 'record age was updated');
+    test('does NOT call persist when _relationshipKey is set', function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      createRecord('owner', { id: 'rel-1', gender: 'female' }, { serialize: false, _relationshipKey: 'owner' });
+
+      assert.ok(persistStub.notCalled, 'sqlDb.persist was NOT called for relationship resolution');
+    });
+
+    test('does NOT call persist when _skipAutoPersist is true', function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      createRecord('owner', { id: 'skip-1', gender: 'male' }, { serialize: false, _skipAutoPersist: true });
+
+      assert.ok(persistStub.notCalled, 'sqlDb.persist was NOT called when _skipAutoPersist is true');
+    });
+
+    test('does NOT call persist when sqlDb is not configured', function(assert) {
+      Orm.initialized = true;
+      Orm.instance.sqlDb = undefined;
+
+      const record = createRecord('owner', { id: 'no-sql', gender: 'male' }, { serialize: false });
+
+      assert.strictEqual(record.id, 'no-sql', 'record created in memory');
+      assert.ok(store.get('owner').has('no-sql'), 'record exists in store');
+    });
+  });
+
+  module('updateRecord auto-persist', function() {
+    test('calls sqlDb.persist with update and old state', function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      const record = createRecord('owner', { id: 'upd-1', gender: 'female', age: 25 }, { serialize: false, _skipAutoPersist: true });
+      persistStub.resetHistory();
+
+      updateRecord(record, { gender: 'male', age: 30 });
+
       assert.ok(persistStub.calledOnce, 'sqlDb.persist was called');
       assert.strictEqual(persistStub.firstCall.args[0], 'update', 'persist called with update operation');
       assert.strictEqual(persistStub.firstCall.args[1], 'owner', 'persist called with model name');
@@ -77,64 +97,81 @@ module('[Unit] Programmatic CRUD | Orm.create / Orm.update / Orm.remove', functi
       assert.strictEqual(context.oldState.age, 25, 'old age captured');
     });
 
-    test('throws when record does not exist', async function(assert) {
-      Orm.initialized = true;
-      Orm.instance.sqlDb = undefined;
-
-      await assert.rejects(
-        Orm.update('owner', 'nonexistent', { gender: 'fail' }),
-        /not found/,
-        'throws record not found error'
-      );
-    });
-
-    test('throws when ORM is not initialized', async function(assert) {
-      Orm.initialized = false;
-
-      await assert.rejects(
-        Orm.update('owner', 'fail', { gender: 'fail' }),
-        /ORM is not ready/,
-        'throws ORM not ready error'
-      );
-    });
-  });
-
-  module('Orm.remove', function() {
-    test('calls sqlDb.persist with delete operation then removes from store', async function(assert) {
+    test('does NOT call persist when isDbRecord is true', function(assert) {
       const persistStub = sinon.stub().resolves();
       Orm.initialized = true;
       Orm.instance.sqlDb = { persist: persistStub };
 
-      createRecord('owner', { id: 'del-1', gender: 'female' }, { serialize: false });
+      const record = createRecord('owner', { id: 'upd-db-1', gender: 'female' }, { serialize: false, _skipAutoPersist: true });
+      persistStub.resetHistory();
+
+      updateRecord(record, { gender: 'male' }, { isDbRecord: true });
+
+      assert.ok(persistStub.notCalled, 'sqlDb.persist was NOT called for DB load update');
+    });
+  });
+
+  module('store.remove auto-persist', function() {
+    test('calls sqlDb.persist with delete when sqlDb is configured', function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      createRecord('owner', { id: 'del-1', gender: 'female' }, { serialize: false, _skipAutoPersist: true });
+      persistStub.resetHistory();
       assert.ok(store.get('owner').has('del-1'), 'record exists before remove');
 
-      await Orm.remove('owner', 'del-1');
+      store.remove('owner', 'del-1');
 
       assert.ok(persistStub.calledOnce, 'sqlDb.persist was called');
       assert.strictEqual(persistStub.firstCall.args[0], 'delete', 'persist called with delete operation');
+      assert.strictEqual(persistStub.firstCall.args[1], 'owner', 'persist called with model name');
       assert.strictEqual(persistStub.firstCall.args[2].recordId, 'del-1', 'persist context contains record id');
       assert.notOk(store.get('owner').has('del-1'), 'record removed from store');
     });
 
-    test('removes from store without SQL when sqlDb is not configured', async function(assert) {
+    test('removes from store without SQL when sqlDb is not configured', function(assert) {
       Orm.initialized = true;
       Orm.instance.sqlDb = undefined;
 
       createRecord('owner', { id: 'del-nosql', gender: 'male' }, { serialize: false });
 
-      await Orm.remove('owner', 'del-nosql');
+      store.remove('owner', 'del-nosql');
 
       assert.notOk(store.get('owner').has('del-nosql'), 'record removed from store');
     });
+  });
 
-    test('throws when ORM is not initialized', async function(assert) {
-      Orm.initialized = false;
+  module('removed static methods', function() {
+    test('Orm.create is not a function', function(assert) {
+      assert.strictEqual(typeof Orm.create, 'undefined', 'Orm.create does not exist');
+    });
 
-      await assert.rejects(
-        Orm.remove('owner', 'fail'),
-        /ORM is not ready/,
-        'throws ORM not ready error'
-      );
+    test('Orm.update is not a function', function(assert) {
+      assert.strictEqual(typeof Orm.update, 'undefined', 'Orm.update does not exist');
+    });
+
+    test('Orm.remove is not a function', function(assert) {
+      assert.strictEqual(typeof Orm.remove, 'undefined', 'Orm.remove does not exist');
+    });
+  });
+
+  module('error handling', function() {
+    test('persist error is caught and logged, not thrown', function(assert) {
+      const done = assert.async();
+      const error = new Error('SQL connection failed');
+      const persistStub = sinon.stub().rejects(error);
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      // This should NOT throw — the error is caught internally
+      const record = createRecord('owner', { id: 'err-1', gender: 'female' }, { serialize: false });
+
+      assert.strictEqual(record.id, 'err-1', 'record created despite persist failure');
+      assert.ok(persistStub.calledOnce, 'persist was attempted');
+
+      // Give the catch handler time to execute
+      setTimeout(() => done(), 50);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **createRecord()** and **updateRecord()** in `manage-record.ts` now auto-persist to SQL (fire-and-forget) when `sqlDb` is configured, with guards for DB loads (`isDbRecord`), relationship resolution (`_relationshipKey`), and REST pipeline (`_skipAutoPersist`)
- **store.remove()** in `store.ts` now auto-persists deletes to SQL before evicting from memory
- **orm-request.ts** passes `_skipAutoPersist: true` from the REST pipeline handlers so `_withHooks` can manage its own awaited persist for pending ID re-keying; delete persist removed from `_withHooks` since `store.remove` handles it
- **Orm.create / Orm.update / Orm.remove** static methods removed from `main.ts` — no longer needed since the data layer handles persistence directly
- Tests rewritten to cover all auto-persist paths, guard conditions, error handling, and removed static methods

## What Changed

| File | Change |
|------|--------|
| `src/manage-record.ts` | Added `_skipAutoPersist` to options interface; fire-and-forget `sqlDb.persist` after createRecord and updateRecord with guard conditions |
| `src/store.ts` | Fire-and-forget `sqlDb.persist('delete', ...)` in `remove()` before eviction |
| `src/orm-request.ts` | `_skipAutoPersist: true` on createRecord/updateRecord calls; persist block scoped to create/update only (not delete) |
| `src/main.ts` | Removed `Orm.create`, `Orm.update`, `Orm.remove` static methods and their imports |
| `src/index.ts` | Updated comments to reflect data-layer auto-persist API |
| `test/unit/programmatic-crud-test.js` | Rewritten: tests createRecord/updateRecord/store.remove auto-persist, guard conditions, error handling, and verifies Orm.create/update/remove are removed |
| `test/unit/fk-resolution-test.js` | Updated to use createRecord directly instead of Orm.create |

## Test plan

- [x] `pnpm run build` compiles clean
- [x] `pnpm test` — all 648 tests pass
- [ ] Verify SQL persistence fires correctly in a live app with PostgreSQL/TimescaleDB configured
- [ ] Verify REST create/update still await persist (pending ID re-keying works)
- [ ] Verify REST delete does not double-persist

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)