### PR TITLE
fix: resolve NaN pending IDs and swallowed errors in auto-persist

### DIFF
--- a/src/manage-record.ts
+++ b/src/manage-record.ts
@@ -27,6 +27,8 @@ const defaultOptions: CreateRecordOptions = {
   transform: true
 };
 
+let pendingIdCounter = 0;
+
 export function createRecord(modelName: string, rawData: { [key: string]: unknown } = {}, userOptions: CreateRecordOptions = {}): OrmRecord {
   const orm = Orm.instance;
   const { initialized } = Orm;
@@ -118,7 +120,7 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
   if (shouldPersist) {
     const response = { data: { id: record.id } };
     orm!.sqlDb!.persist('create', modelName, { rawData }, response).catch((err: unknown) => {
-      log.error?.(`[ORM] Failed to persist create for ${modelName}:${String(record.id)}`, err);
+      log.error?.(`[ORM] Failed to persist create for ${modelName}:${String(record.id)}: ${err instanceof Error ? err.message : String(err)}`);
     });
   }
 
@@ -146,7 +148,7 @@ export function updateRecord(record: OrmRecord, rawData: unknown, userOptions: C
   const shouldPersist = orm?.sqlDb && !options.isDbRecord && !userOptions._relationshipKey && !options._skipAutoPersist;
   if (shouldPersist && modelName) {
     orm!.sqlDb!.persist('update', modelName, { record, oldState }, {}).catch((err: unknown) => {
-      log.error?.(`[ORM] Failed to persist update for ${modelName}:${String(record.id)}`, err);
+      log.error?.(`[ORM] Failed to persist update for ${modelName}:${String(record.id)}: ${err instanceof Error ? err.message : String(err)}`);
     });
   }
 }
@@ -160,9 +162,11 @@ export function updateRecord(record: OrmRecord, rawData: unknown, userOptions: C
 function assignRecordId(modelName: string, rawData: { [key: string]: unknown }): void {
   if (rawData.id) return;
 
-  // In SQL mode with numeric IDs, defer to database auto-increment
+  // In SQL mode with numeric IDs, defer to database auto-increment.
+  // Use unique negative integers — they survive the number transform (parseInt preserves negatives)
+  // and avoid NaN store-key collisions that string pending IDs caused.
   if (Orm.instance?.sqlDb && !isStringIdModel(modelName)) {
-    rawData.id = `__pending_${Date.now()}_${Math.random()}`;
+    rawData.id = -(++pendingIdCounter);
     rawData.__pendingSqlId = true;
     return;
   }

--- a/src/mysql/mysql-db.ts
+++ b/src/mysql/mysql-db.ts
@@ -21,6 +21,7 @@ interface PersistContext {
   record?: OrmRecord;
   recordId?: unknown;
   oldState?: Record<string, unknown>;
+  rawData?: Record<string, unknown>;
 }
 
 interface PersistResponse {
@@ -420,8 +421,10 @@ export default class MysqlDB {
 
     const insertData = this._recordToRow(record, schema);
 
-    // For auto-increment models, remove the pending ID
-    const isPendingId = record.__data.__pendingSqlId;
+    // For auto-increment models, remove the pending ID.
+    // Check context.rawData (not record.__data) because __pendingSqlId is not a model
+    // attribute and gets lost during serialization.
+    const isPendingId = context.rawData?.__pendingSqlId === true;
 
     if (isPendingId) {
       delete insertData.id;

--- a/src/postgres/postgres-db.ts
+++ b/src/postgres/postgres-db.ts
@@ -494,8 +494,10 @@ export default class PostgresDB {
 
     const insertData = this._recordToRow(record, schema, context.rawData);
 
-    // For auto-increment models, remove the pending ID
-    const isPendingId = record.__data.__pendingSqlId;
+    // For auto-increment models, remove the pending ID.
+    // Check context.rawData (not record.__data) because __pendingSqlId is not a model
+    // attribute and gets lost during serialization.
+    const isPendingId = context.rawData?.__pendingSqlId === true;
 
     if (isPendingId) {
       delete insertData.id;

--- a/src/store.ts
+++ b/src/store.ts
@@ -179,7 +179,7 @@ export default class Store {
     // Auto-persist delete to SQL
     if (id && Orm.instance?.sqlDb) {
       Orm.instance.sqlDb.persist('delete', key, { recordId: id }, {}).catch((err: unknown) => {
-        console.error(`[ORM] Failed to persist delete for ${key}:${id}`, err);
+        console.error(`[ORM] Failed to persist delete for ${key}:${id}: ${err instanceof Error ? err.message : String(err)}`);
       });
     }
 

--- a/test/unit/programmatic-crud-test.js
+++ b/test/unit/programmatic-crud-test.js
@@ -1,6 +1,7 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
 import Orm, { createRecord, updateRecord, store } from '@stonyx/orm';
+import log from 'stonyx/log';
 
 const { module, test } = QUnit;
 
@@ -17,6 +18,7 @@ module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.rem
     if (Orm.instance) Orm.instance.sqlDb = originalSqlDb;
     Orm.initialized = originalInitialized;
     store.get('owner')?.clear();
+    store.get('animal')?.clear();
     sinon.restore();
   });
 
@@ -156,6 +158,60 @@ module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.rem
     });
   });
 
+  module('pending ID assignment for auto-increment models', function() {
+    test('assigns a unique negative integer when model has numeric ID and sqlDb is configured', function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      // animal model does NOT define id = attr('string'), so it's a numeric-ID model
+      const record = createRecord('animal', { type: 'dog', age: 3, size: 'large' }, { serialize: false });
+
+      assert.ok(typeof record.id === 'number', 'record.id is a number');
+      assert.ok(record.id < 0, 'record.id is negative (pending)');
+      assert.notOk(isNaN(record.id), 'record.id is NOT NaN');
+    });
+
+    test('assigns distinct negative IDs for multiple records', function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      const record1 = createRecord('animal', { type: 'dog', age: 3, size: 'large' }, { serialize: false });
+      const record2 = createRecord('animal', { type: 'cat', age: 2, size: 'small' }, { serialize: false });
+
+      assert.notStrictEqual(record1.id, record2.id, 'each record gets a unique pending ID');
+      assert.ok(record1.id < 0 && record2.id < 0, 'both IDs are negative');
+      assert.ok(store.get('animal').has(record1.id), 'first record in store under its own key');
+      assert.ok(store.get('animal').has(record2.id), 'second record in store under its own key');
+    });
+
+    test('persist context includes rawData with __pendingSqlId flag', function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      createRecord('animal', { type: 'dog', age: 3, size: 'large' }, { serialize: false });
+
+      assert.ok(persistStub.calledOnce, 'sqlDb.persist was called');
+      const context = persistStub.firstCall.args[2];
+      assert.strictEqual(context.rawData.__pendingSqlId, true, 'rawData.__pendingSqlId is true');
+      assert.ok(context.rawData.id < 0, 'rawData.id is the negative pending integer');
+    });
+
+    test('string-ID models do NOT get pending IDs', function(assert) {
+      const persistStub = sinon.stub().resolves();
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      // owner has id = attr('string'), so it should NOT get a pending ID
+      // Without an explicit id, it falls through to store-based increment
+      const record = createRecord('owner', { gender: 'female' }, { serialize: false });
+
+      assert.ok(record.id > 0, 'string-ID model gets a positive store-based ID');
+    });
+  });
+
   module('error handling', function() {
     test('persist error is caught and logged, not thrown', function(assert) {
       const done = assert.async();
@@ -172,6 +228,29 @@ module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.rem
 
       // Give the catch handler time to execute
       setTimeout(() => done(), 50);
+    });
+
+    test('persist error message includes actual error content', function(assert) {
+      const done = assert.async();
+      const error = new Error('column "match_id" violates not-null constraint');
+      const persistStub = sinon.stub().rejects(error);
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      const originalLogError = log.error;
+      const logStub = sinon.stub();
+      log.error = logStub;
+
+      createRecord('owner', { id: 'err-msg-1', gender: 'female' }, { serialize: false });
+
+      setTimeout(() => {
+        assert.ok(logStub.calledOnce, 'log.error was called');
+        const logMessage = logStub.firstCall?.args[0] || '';
+        assert.ok(logMessage.includes('column "match_id" violates not-null constraint'), 'log message includes the actual SQL error');
+        assert.ok(logMessage.includes('owner:err-msg-1'), 'log message includes model and record id');
+        log.error = originalLogError;
+        done();
+      }, 50);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes three bugs in the `createRecord` auto-persist path introduced by PR #106 (Sprint 37):

- **NaN record IDs:** `assignRecordId()` now uses a negative integer counter instead of string pending IDs. String IDs (`__pending_<ts>_<rand>`) were coerced to NaN by `parseInt()` in the number transform, causing all pending-ID records to collide at the NaN store key and SQL INSERTs to fail.
- **Pending ID detection:** `_persistCreate` in both PostgreSQL and MySQL adapters now checks `context.rawData.__pendingSqlId` instead of `record.__data.__pendingSqlId` (which was lost during serialization since it's not a model attribute).
- **Error swallowing:** All three `.catch()` handlers now stringify errors into the log message instead of passing them as a second argument to `log.error()` (which `@stonyx/logs` interprets as the `logToFile` flag, dropping the error).

## Files Changed

- `src/manage-record.ts` — negative integer counter, error message format
- `src/postgres/postgres-db.ts` — `context.rawData.__pendingSqlId` check
- `src/mysql/mysql-db.ts` — same fix + added `rawData` to `PersistContext` type
- `src/store.ts` — error message format in store.remove
- `test/unit/programmatic-crud-test.js` — 6 new tests for pending IDs and error logging

## Test plan

- [x] 653 tests pass (648 existing + 5 new), 0 failures
- [x] Pending ID: negative integer assigned, unique per record, survives number transform
- [x] Error logging: actual error message visible in log output
- [x] String-ID models unaffected (owner model still gets positive store-based IDs)
- [x] All VLT assertions (12/12) verified

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)