### PR TITLE
fix: make SQL persist failures observable via onPersistError callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { count, avg, sum, min, max } from './aggregates.js';
 
 export { default } from './main.js';
 export { store, relationships } from './main.js';
+export type { PersistErrorDetail } from './main.js';
 export { Model, View, Serializer }; // base classes
 export { attr, belongsTo, hasMany, createRecord, updateRecord }; // helpers
 export { count, avg, sum, min, max }; // aggregate helpers

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ const defaultOptions: OrmOptions = {
 }
 
 export interface PersistErrorDetail {
-  operation: string;
+  operation: 'create' | 'update' | 'delete';
   modelName: string;
   recordId: unknown;
   error: Error;

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,13 @@ const defaultOptions: OrmOptions = {
   dbType: 'json'
 }
 
+export interface PersistErrorDetail {
+  operation: string;
+  modelName: string;
+  recordId: unknown;
+  error: Error;
+}
+
 export default class Orm {
   static initialized: boolean = false;
   static relationships: Map<string, Map<string, unknown>> = new Map();
@@ -64,6 +71,8 @@ export default class Orm {
   options!: OrmOptions;
   sqlDb?: SqlDb;
   db?: OrmDB | SqlDb;
+
+  private _persistErrorHandler: ((detail: PersistErrorDetail) => void) | null = null;
 
   constructor(options: OrmOptions = {}) {
     if (Orm.instance) return Orm.instance;
@@ -212,6 +221,25 @@ export default class Orm {
   isView(modelName: string): boolean {
     const modelClassPrefix = kebabCaseToPascalCase(modelName);
     return !!this.views[`${modelClassPrefix}View`];
+  }
+
+  /**
+   * Register a callback to be invoked when a fire-and-forget SQL persist fails.
+   * Without a handler, persist errors are logged via log.error (backwards-compatible).
+   */
+  onPersistError(handler: (detail: PersistErrorDetail) => void): void {
+    this._persistErrorHandler = handler;
+  }
+
+  /**
+   * Emit a persist error to the registered handler, or fall back to log.error.
+   */
+  emitPersistError(detail: PersistErrorDetail): void {
+    if (this._persistErrorHandler) {
+      this._persistErrorHandler(detail);
+    } else {
+      log.error?.(`[ORM] Failed to persist ${detail.operation} for ${detail.modelName}:${String(detail.recordId)}: ${detail.error.message}`);
+    }
   }
 
   // Queue warnings to avoid the same error from being logged in the same iteration

--- a/src/main.ts
+++ b/src/main.ts
@@ -227,7 +227,7 @@ export default class Orm {
    * Register a callback to be invoked when a fire-and-forget SQL persist fails.
    * Without a handler, persist errors are logged via log.error (backwards-compatible).
    */
-  onPersistError(handler: (detail: PersistErrorDetail) => void): void {
+  onPersistError(handler: ((detail: PersistErrorDetail) => void) | null): void {
     this._persistErrorHandler = handler;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -235,10 +235,17 @@ export default class Orm {
    * Emit a persist error to the registered handler, or fall back to log.error.
    */
   emitPersistError(detail: PersistErrorDetail): void {
+    const fallbackLog = () => log.error?.(`[ORM] Failed to persist ${detail.operation} for ${detail.modelName}:${String(detail.recordId)}: ${detail.error.message}`);
+
     if (this._persistErrorHandler) {
-      this._persistErrorHandler(detail);
+      try {
+        this._persistErrorHandler(detail);
+      } catch (handlerError) {
+        fallbackLog();
+        log.error?.(`[ORM] onPersistError handler threw: ${handlerError instanceof Error ? handlerError.message : String(handlerError)}`);
+      }
     } else {
-      log.error?.(`[ORM] Failed to persist ${detail.operation} for ${detail.modelName}:${String(detail.recordId)}: ${detail.error.message}`);
+      fallbackLog();
     }
   }
 

--- a/src/manage-record.ts
+++ b/src/manage-record.ts
@@ -3,7 +3,6 @@ import OrmRecord from './record.js';
 import { getGlobalRegistry, getPendingRegistry, getPendingBelongsToRegistry, getBelongsToRegistry, getHasManyRegistry } from './relationships.js';
 import type Serializer from './serializer.js';
 import { isOrmRecord } from './utils.js';
-import log from 'stonyx/log';
 
 interface CreateRecordOptions {
   isDbRecord?: boolean;
@@ -120,7 +119,12 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
   if (shouldPersist) {
     const response = { data: { id: record.id } };
     orm!.sqlDb!.persist('create', modelName, { rawData }, response).catch((err: unknown) => {
-      log.error?.(`[ORM] Failed to persist create for ${modelName}:${String(record.id)}: ${err instanceof Error ? err.message : String(err)}`);
+      orm!.emitPersistError({
+        operation: 'create',
+        modelName,
+        recordId: record.id,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
     });
   }
 
@@ -148,7 +152,12 @@ export function updateRecord(record: OrmRecord, rawData: unknown, userOptions: C
   const shouldPersist = orm?.sqlDb && !options.isDbRecord && !userOptions._relationshipKey && !options._skipAutoPersist;
   if (shouldPersist && modelName) {
     orm!.sqlDb!.persist('update', modelName, { record, oldState }, {}).catch((err: unknown) => {
-      log.error?.(`[ORM] Failed to persist update for ${modelName}:${String(record.id)}: ${err instanceof Error ? err.message : String(err)}`);
+      orm!.emitPersistError({
+        operation: 'update',
+        modelName,
+        recordId: record.id,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
     });
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -179,7 +179,12 @@ export default class Store {
     // Auto-persist delete to SQL
     if (id && Orm.instance?.sqlDb) {
       Orm.instance.sqlDb.persist('delete', key, { recordId: id }, {}).catch((err: unknown) => {
-        console.error(`[ORM] Failed to persist delete for ${key}:${id}: ${err instanceof Error ? err.message : String(err)}`);
+        Orm.instance.emitPersistError({
+          operation: 'delete',
+          modelName: key,
+          recordId: id,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
       });
     }
 

--- a/test/unit/programmatic-crud-test.ts
+++ b/test/unit/programmatic-crud-test.ts
@@ -213,25 +213,100 @@ module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.rem
     });
   });
 
-  module('error handling', function() {
-    test('persist error is caught and logged, not thrown', function(assert) {
+  module('error handling — onPersistError callback', function(hooks) {
+    let originalHandler;
+
+    hooks.afterEach(function() {
+      // Reset the persist error handler after each test
+      if (Orm.instance) {
+        Orm.instance.onPersistError(null);
+      }
+    });
+
+    test('createRecord with SQL persist failure invokes registered onPersistError callback', function(assert) {
       const done = assert.async();
       const error = new Error('SQL connection failed');
       const persistStub = sinon.stub().rejects(error);
       Orm.initialized = true;
       Orm.instance.sqlDb = { persist: persistStub };
 
-      // This should NOT throw — the error is caught internally
-      const record = createRecord('owner', { id: 'err-1', gender: 'female' }, { serialize: false });
+      const handlerStub = sinon.stub();
+      Orm.instance.onPersistError(handlerStub);
 
-      assert.strictEqual(record.id, 'err-1', 'record created despite persist failure');
-      assert.ok(persistStub.calledOnce, 'persist was attempted');
+      const record = createRecord('owner', { id: 'err-cb-1', gender: 'female' }, { serialize: false });
 
-      // Give the catch handler time to execute
-      setTimeout(() => done(), 50);
+      assert.strictEqual(record.id, 'err-cb-1', 'record created despite persist failure');
+
+      setTimeout(() => {
+        assert.ok(handlerStub.calledOnce, 'onPersistError handler was called');
+        const detail = handlerStub.firstCall.args[0];
+        assert.strictEqual(detail.operation, 'create', 'detail.operation is create');
+        assert.strictEqual(detail.modelName, 'owner', 'detail.modelName is owner');
+        assert.strictEqual(detail.recordId, 'err-cb-1', 'detail.recordId is err-cb-1');
+        assert.ok(detail.error instanceof Error, 'detail.error is an Error');
+        assert.strictEqual(detail.error.message, 'SQL connection failed', 'detail.error has correct message');
+        done();
+      }, 50);
     });
 
-    test('persist error message includes actual error content', function(assert) {
+    test('updateRecord with SQL persist failure invokes registered onPersistError callback', function(assert) {
+      const done = assert.async();
+      const error = new Error('update constraint violation');
+      const persistStub = sinon.stub();
+      // Resolve for create, reject for update
+      persistStub.onFirstCall().resolves();
+      persistStub.onSecondCall().rejects(error);
+
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      const record = createRecord('owner', { id: 'err-cb-2', gender: 'female' }, { serialize: false, _skipAutoPersist: true });
+
+      const handlerStub = sinon.stub();
+      Orm.instance.onPersistError(handlerStub);
+
+      updateRecord(record, { gender: 'male' });
+
+      setTimeout(() => {
+        assert.ok(handlerStub.calledOnce, 'onPersistError handler was called');
+        const detail = handlerStub.firstCall.args[0];
+        assert.strictEqual(detail.operation, 'update', 'detail.operation is update');
+        assert.strictEqual(detail.modelName, 'owner', 'detail.modelName is owner');
+        assert.strictEqual(detail.recordId, 'err-cb-2', 'detail.recordId is err-cb-2');
+        assert.ok(detail.error instanceof Error, 'detail.error is an Error');
+        assert.strictEqual(detail.error.message, 'update constraint violation', 'detail.error has correct message');
+        done();
+      }, 50);
+    });
+
+    test('store.remove with SQL persist failure invokes registered onPersistError callback', function(assert) {
+      const done = assert.async();
+      const error = new Error('delete FK constraint');
+      const persistStub = sinon.stub().rejects(error);
+
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      createRecord('owner', { id: 'err-cb-3', gender: 'male' }, { serialize: false, _skipAutoPersist: true });
+
+      const handlerStub = sinon.stub();
+      Orm.instance.onPersistError(handlerStub);
+
+      store.remove('owner', 'err-cb-3');
+
+      setTimeout(() => {
+        assert.ok(handlerStub.calledOnce, 'onPersistError handler was called');
+        const detail = handlerStub.firstCall.args[0];
+        assert.strictEqual(detail.operation, 'delete', 'detail.operation is delete');
+        assert.strictEqual(detail.modelName, 'owner', 'detail.modelName is owner');
+        assert.strictEqual(detail.recordId, 'err-cb-3', 'detail.recordId is err-cb-3');
+        assert.ok(detail.error instanceof Error, 'detail.error is an Error');
+        assert.strictEqual(detail.error.message, 'delete FK constraint', 'detail.error has correct message');
+        done();
+      }, 50);
+    });
+
+    test('when no onPersistError handler is registered, persist errors fall back to log.error', function(assert) {
       const done = assert.async();
       const error = new Error('column "match_id" violates not-null constraint');
       const persistStub = sinon.stub().rejects(error);
@@ -242,14 +317,84 @@ module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.rem
       const logStub = sinon.stub();
       log.error = logStub;
 
-      createRecord('owner', { id: 'err-msg-1', gender: 'female' }, { serialize: false });
+      createRecord('owner', { id: 'err-fallback-1', gender: 'female' }, { serialize: false });
 
       setTimeout(() => {
-        assert.ok(logStub.calledOnce, 'log.error was called');
+        assert.ok(logStub.calledOnce, 'log.error was called as fallback');
         const logMessage = logStub.firstCall?.args[0] || '';
         assert.ok(logMessage.includes('column "match_id" violates not-null constraint'), 'log message includes the actual SQL error');
-        assert.ok(logMessage.includes('owner:err-msg-1'), 'log message includes model and record id');
+        assert.ok(logMessage.includes('owner:err-fallback-1'), 'log message includes model and record id');
         log.error = originalLogError;
+        done();
+      }, 50);
+    });
+
+    test('createRecord still returns the record synchronously regardless of persist outcome', function(assert) {
+      const error = new Error('SQL failure');
+      const persistStub = sinon.stub().rejects(error);
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      const handlerStub = sinon.stub();
+      Orm.instance.onPersistError(handlerStub);
+
+      const record = createRecord('owner', { id: 'sync-1', gender: 'female' }, { serialize: false });
+
+      // Verify synchronous return — record is available immediately, not a Promise
+      assert.strictEqual(record.id, 'sync-1', 'record returned synchronously with correct id');
+      assert.notOk(record instanceof Promise, 'return value is NOT a Promise');
+      assert.ok(store.get('owner').has('sync-1'), 'record is in the store immediately');
+    });
+
+    test('updateRecord still returns void synchronously regardless of persist outcome', function(assert) {
+      const error = new Error('SQL failure');
+      const persistStub = sinon.stub().rejects(error);
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      const record = createRecord('owner', { id: 'sync-2', gender: 'female' }, { serialize: false, _skipAutoPersist: true });
+
+      const handlerStub = sinon.stub();
+      Orm.instance.onPersistError(handlerStub);
+
+      const result = updateRecord(record, { gender: 'male' });
+
+      // Verify synchronous return — void, not a Promise
+      assert.strictEqual(result, undefined, 'updateRecord returns void (undefined)');
+    });
+
+    test('_skipAutoPersist callers are unaffected — no persist attempt, no callback invocation', function(assert) {
+      const done = assert.async();
+      const persistStub = sinon.stub().rejects(new Error('should not be called'));
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      const handlerStub = sinon.stub();
+      Orm.instance.onPersistError(handlerStub);
+
+      createRecord('owner', { id: 'skip-err-1', gender: 'female' }, { serialize: false, _skipAutoPersist: true });
+
+      setTimeout(() => {
+        assert.ok(persistStub.notCalled, 'sqlDb.persist was NOT called');
+        assert.ok(handlerStub.notCalled, 'onPersistError handler was NOT called');
+        done();
+      }, 50);
+    });
+
+    test('isDbRecord callers are unaffected — no persist attempt, no callback invocation', function(assert) {
+      const done = assert.async();
+      const persistStub = sinon.stub().rejects(new Error('should not be called'));
+      Orm.initialized = true;
+      Orm.instance.sqlDb = { persist: persistStub };
+
+      const handlerStub = sinon.stub();
+      Orm.instance.onPersistError(handlerStub);
+
+      createRecord('owner', { id: 'db-err-1', gender: 'male' }, { serialize: false, isDbRecord: true });
+
+      setTimeout(() => {
+        assert.ok(persistStub.notCalled, 'sqlDb.persist was NOT called');
+        assert.ok(handlerStub.notCalled, 'onPersistError handler was NOT called');
         done();
       }, 50);
     });

--- a/test/unit/programmatic-crud-test.ts
+++ b/test/unit/programmatic-crud-test.ts
@@ -214,13 +214,19 @@ module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.rem
   });
 
   module('error handling — onPersistError callback', function(hooks) {
-    let originalHandler;
+    let originalLogError;
+
+    hooks.beforeEach(function() {
+      originalLogError = log.error;
+    });
 
     hooks.afterEach(function() {
       // Reset the persist error handler after each test
       if (Orm.instance) {
         Orm.instance.onPersistError(null);
       }
+      // Restore log.error in case a test stubbed it
+      log.error = originalLogError;
     });
 
     test('createRecord with SQL persist failure invokes registered onPersistError callback', function(assert) {
@@ -252,10 +258,7 @@ module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.rem
     test('updateRecord with SQL persist failure invokes registered onPersistError callback', function(assert) {
       const done = assert.async();
       const error = new Error('update constraint violation');
-      const persistStub = sinon.stub();
-      // Resolve for create, reject for update
-      persistStub.onFirstCall().resolves();
-      persistStub.onSecondCall().rejects(error);
+      const persistStub = sinon.stub().rejects(error);
 
       Orm.initialized = true;
       Orm.instance.sqlDb = { persist: persistStub };
@@ -313,7 +316,6 @@ module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.rem
       Orm.initialized = true;
       Orm.instance.sqlDb = { persist: persistStub };
 
-      const originalLogError = log.error;
       const logStub = sinon.stub();
       log.error = logStub;
 
@@ -324,7 +326,6 @@ module('[Unit] Data-Layer Auto-Persist | createRecord / updateRecord / store.rem
         const logMessage = logStub.firstCall?.args[0] || '';
         assert.ok(logMessage.includes('column "match_id" violates not-null constraint'), 'log message includes the actual SQL error');
         assert.ok(logMessage.includes('owner:err-fallback-1'), 'log message includes model and record id');
-        log.error = originalLogError;
         done();
       }, 50);
     });


### PR DESCRIPTION
## Summary

Closes abofs/stonyx#45

- Adds `onPersistError(handler)` callback on the ORM instance that is invoked when fire-and-forget SQL persist calls fail
- Updates all 3 persist call sites (`createRecord`, `updateRecord`, `store.remove`) to route errors through `emitPersistError()`
- When no handler is registered, falls back to `log.error` (backwards-compatible)
- Preserves synchronous API contract — `createRecord` returns `OrmRecord`, `updateRecord` returns `void`
- Exports `PersistErrorDetail` type for consumers
- 8 regression tests covering all error paths, sync contract, and skip-persist flags

## Cross-reference

Unblocks mstonepc/trix#541

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] 8 new regression tests for persist error callback behavior
- [x] Existing test suite passes (263 pass, 37 fail — same as dev baseline)
- [ ] Verify `_skipAutoPersist` and `isDbRecord` paths remain unaffected
- [ ] Verify backwards compatibility (no handler = log.error fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)