### PR TITLE
docs(orm): document ModelProperty field assignment semantics

### DIFF
--- a/docs/usage-patterns.md
+++ b/docs/usage-patterns.md
@@ -298,3 +298,44 @@ store.remove('owner-stats', id);      // Throws: Cannot remove records from read
 ### REST API
 
 Only GET endpoints are mounted for views — no POST, PATCH, or DELETE.
+
+## 11. Field Assignment Semantics
+
+ModelProperty treats `undefined` and `null` as **distinct sentinels** by design:
+
+- `undefined` means **"not provided — leave the existing value alone"**
+- `null` means **"explicitly clear the field"**
+
+This split is what makes PATCH-style partial updates work: a payload that omits a field (`undefined` at that key) leaves the stored value untouched, while a payload that sets a field to `null` actually clears it.
+
+### The Four Assignment Paths
+
+| Path | Result |
+|------|--------|
+| `record.field = undefined` | **No-op** — existing value preserved |
+| `record.field = null` | Sets to `null` (clears the field) |
+| Update payload omits the field | Field not touched |
+| Update payload sets field to `null` | Sets to `null` |
+
+### Example
+
+```javascript
+import { createRecord, updateRecord } from '@stonyx/orm';
+
+const record = createRecord('owner', { id: 'bob', gender: 'female' }, { serialize: false });
+
+record.gender = undefined; // no-op — still 'female'
+record.gender = null;      // clears — now null
+
+// Partial update: omitted fields stay untouched
+record.gender = 'male';
+updateRecord(record, { age: 31 });  // gender still 'male'
+updateRecord(record, { sex: null }); // explicitly clears gender (mapped via serializer)
+```
+
+**Key Points:**
+- Direct assignment of `undefined` is safe — it never overwrites
+- Direct assignment of `null` is the canonical way to clear a field (no `setNull()` helper is needed)
+- Update payloads behave the same way: missing key = untouched, explicit `null` = cleared
+- The setter lives in [`src/model-property.ts`](../src/model-property.ts) (the `if (newValue === undefined) return;` no-op); the partial-update skip lives in [`src/serializer.ts`](../src/serializer.ts) (`if (data === undefined && options.update) continue;`)
+


### PR DESCRIPTION
## Summary

Adds a new `## 11. Field Assignment Semantics` subsection to `docs/usage-patterns.md` documenting the `undefined`-vs-`null` design split in `ModelProperty`:

- `undefined` is the **"don't touch"** sentinel (no-op on the setter; skipped by the serializer on updates)
- `null` is the **"explicitly clear"** sentinel
- Together these enable PATCH-style partial updates — a payload that omits a field leaves the existing value untouched, while an explicit `null` clears it

The new subsection includes:

1. Design-intent statement
2. Table of the four assignment paths (direct `= undefined`, direct `= null`, payload omits, payload sets `null`)
3. Code example covering both clearing and partial-update behavior
4. Cross-references to `src/model-property.ts:31` and `src/serializer.ts:89`

Doc-only change — no code in `src/` was modified. Source behavior confirmed unchanged.

Closes #122

## Test Plan

- [x] Read `src/model-property.ts:24-34` — `if (newValue === undefined) return;` confirmed at line 31
- [x] Read `src/serializer.ts:89` — `if (data === undefined && options.update) continue;` confirmed
- [x] One-off REPL probe against `test/sample/owner` model confirmed all four paths behave as documented:
  - `record.gender = undefined` -> value preserved
  - `record.gender = null` -> cleared
  - `updateRecord(rec, {})` (omitted) -> value preserved
  - `updateRecord(rec, { sex: null })` (payload null, mapped via serializer) -> cleared
- [ ] Markdown renders cleanly in GitHub preview (table syntax, code fences, relative links to `src/`)

Generated with [Claude Code](https://claude.com/claude-code)