### PR TITLE
fix(orm): self-register db log type in Orm.init

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -90,6 +90,11 @@ export default class Orm {
   }
 
   async init(): Promise<void> {
+    // Self-register so log.db works even when @stonyx/orm is in the
+    // consumer's `dependencies` (stonyx loader only merges devDependencies).
+    const { logColor = 'white', logMethod = 'db' } = config.orm;
+    log.defineType(logMethod, logColor);
+
     const { paths, restServer } = config.orm;
 
     const promises: Promise<unknown>[] = ['Model', 'Serializer', 'Transform'].map(type => {

--- a/src/types/orm-types.ts
+++ b/src/types/orm-types.ts
@@ -55,6 +55,8 @@ export interface OrmSection {
   mysql?: OrmMysqlConfig;
   postgres?: OrmPostgresConfig;
   timescale?: OrmPostgresConfig;
+  logColor?: string;
+  logMethod?: string;
   [key: string]: unknown;
 }
 

--- a/src/types/stonyx.d.ts
+++ b/src/types/stonyx.d.ts
@@ -5,7 +5,13 @@ declare module 'stonyx/config' {
 }
 
 declare module 'stonyx/log' {
-  const log: Record<string, ((...args: unknown[]) => void) | undefined>;
+  interface Log {
+    db(message: string): void;
+    error(message: string, ...args: unknown[]): void;
+    defineType(type: string, setting: string, options?: Record<string, unknown> | null): void;
+    [key: string]: ((...args: unknown[]) => void) | undefined;
+  }
+  const log: Log;
   export default log;
 }
 

--- a/test/unit/orm-self-register-log-test.ts
+++ b/test/unit/orm-self-register-log-test.ts
@@ -1,0 +1,43 @@
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import Orm from '../../src/main.js';
+import log from 'stonyx/log';
+
+const { module, test } = QUnit;
+
+module('[Unit] Orm self-registers log type in init() (#124)', function (hooks) {
+  let originalInstance: Orm;
+
+  hooks.beforeEach(function () {
+    originalInstance = Orm.instance;
+  });
+
+  hooks.afterEach(function () {
+    Orm.instance = originalInstance;
+    sinon.restore();
+  });
+
+  test('registers db log type on init', async function (assert) {
+    assert.strictEqual(typeof log.defineType, 'function', 'log.defineType is available');
+
+    Orm.instance = undefined as unknown as Orm;
+    const orm = new Orm({ dbType: 'none' });
+    // init() may throw later (missing configured paths in the unit harness) but
+    // defineType runs as the first statement, before any throw.
+    try { await orm.init(); } catch { /* expected */ }
+
+    assert.strictEqual(typeof log.db, 'function', 'log.db is callable after init');
+  });
+
+  test('idempotent: calling init twice does not throw', async function (assert) {
+    Orm.instance = undefined as unknown as Orm;
+    const orm1 = new Orm({ dbType: 'none' });
+    try { await orm1.init(); } catch { /* expected */ }
+
+    Orm.instance = undefined as unknown as Orm;
+    const orm2 = new Orm({ dbType: 'none' });
+    try { await orm2.init(); } catch { /* expected */ }
+
+    assert.strictEqual(typeof log.db, 'function', 'log.db still callable after second init');
+  });
+});


### PR DESCRIPTION
## Summary

Prepend `log.defineType(logMethod, logColor)` as the first statement of `Orm.init()` so `log.db` works even when `@stonyx/orm` is placed in a consumer's `dependencies` (the stonyx loader only merges `devDependencies`, so this module's `config/environment.js` is otherwise silently skipped and `logMethod` never reaches chronicle).

Defaults come from `config/environment.js` with literal fallbacks (`logMethod: 'db'`, `logColor: 'white'`).

## Changes

- `src/main.ts` — self-register as first statement of `Orm.init()`
- `src/types/orm-types.ts` — add `logColor?`/`logMethod?` to `OrmSection`
- `src/types/stonyx.d.ts` — type `db`, `error`, `defineType` on the `Log` interface; keep callable index signature for existing `log.warn?.(...)` / `log.db?.(...)` callsites
- `test/unit/orm-self-register-log-test.ts` — two unit tests mirroring sockets precedent

## Cross-links

- abofs/stonyx#75 — architectural decision, full rationale for Option B
- abofs/stonyx-sockets#30 — precedent PR (mimicked exactly)

Closes #124

## Test plan

- [ ] CI green on dev PR
- [ ] No regressions in typecheck for existing `log.*` callsites

## Notes

- Local `pnpm test` skipped per known-broken orm test suite (see stonyx-orm#120 carryover); relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)