### PR TITLE
docs: drop Language row from Tech Stack table

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -31,7 +31,6 @@ A lightweight ORM for the Stonyx framework that provides structured data modelin
 
 | Category | Technology | Version | Notes |
 |----------|-----------|---------|-------|
-| Language | JavaScript (ES Modules) | Node 24.13.0 | `"type": "module"` in package.json |
 | Framework | Stonyx | file ref | Core framework (peer dependency) |
 | Database (JSON) | Built-in `DB` class | N/A | File-based JSON persistence |
 | Database (SQL) | MySQL via mysql2 | ^3.0.0 | Optional peer dependency |


### PR DESCRIPTION
## Summary

Drops the `| Language | JavaScript (ES Modules) | ... |` row from the Tech Stack table in `docs/project-structure.md`. Stonyx family no longer promotes source language in module docs — the intent is to drop language promotion entirely rather than swap to "TypeScript". Matches the pattern in `stonyx-events/docs/project-structure.md` which omits a Language row.

Refs abofs/stonyx#77 (umbrella).

## Validation (Tier-1, ephemeral)

- `grep -n 'JavaScript (ES Modules)' docs/project-structure.md` → zero matches ✅
- `grep -n -E '(100%|pure)\s*JavaScript' docs/project-structure.md` → zero matches ✅

## Test plan

- [x] Doc renders on GitHub with Tech Stack table preserved minus the Language row
- [x] No behavioral code changes (doc-only)