### PR TITLE
feat(dynamodb): DynamoDB driver implementing SqlDb PAL contract

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -33,6 +33,9 @@ const {
   TIMESCALE_DATABASE,
   TIMESCALE_CONNECTION_LIMIT,
   TIMESCALE_MIGRATIONS_DIR,
+  DYNAMODB_REGION,
+  DYNAMODB_ENDPOINT,
+  DYNAMODB_TABLE_PREFIX,
 } = process.env;
 
 export default {
@@ -83,6 +86,11 @@ export default {
     connectionLimit: parseInt(TIMESCALE_CONNECTION_LIMIT ?? '10'),
     migrationsDir: TIMESCALE_MIGRATIONS_DIR ?? 'migrations',
     migrationsTable: '__migrations',
+  } : undefined,
+  dynamodb: DYNAMODB_REGION ? {
+    region: DYNAMODB_REGION,
+    endpoint: DYNAMODB_ENDPOINT || undefined,
+    tablePrefix: DYNAMODB_TABLE_PREFIX || '',
   } : undefined,
   restServer: {
     enabled: ORM_USE_REST_SERVER ?? 'true', // Whether to load restServer for automatic route setup or

--- a/package.json
+++ b/package.json
@@ -72,11 +72,19 @@
     "stonyx": "0.2.3-beta.66"
   },
   "peerDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
     "@stonyx/rest-server": ">=0.2.1-beta.14",
     "mysql2": "^3.0.0",
     "pg": "^8.0.0"
   },
   "peerDependenciesMeta": {
+    "@aws-sdk/client-dynamodb": {
+      "optional": true
+    },
+    "@aws-sdk/lib-dynamodb": {
+      "optional": true
+    },
     "mysql2": {
       "optional": true
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,6 +28,13 @@ const commands: Record<string, Command> = {
     description: 'Generate a MySQL migration from current model schemas',
     bootstrap: true,
     run: async (args) => {
+      const config = (await import('stonyx/config')).default;
+
+      if (config.orm.dynamodb) {
+        console.log('DynamoDB does not use file-based migrations. Use db:sync to provision tables.');
+        return;
+      }
+
       const description = args?.join(' ') || 'migration';
       const { generateMigration } = await import('./mysql/migration-generator.js');
       const result = await generateMigration(description);
@@ -39,12 +46,36 @@ const commands: Record<string, Command> = {
       }
     }
   },
+  'db:sync': {
+    description: 'Provision DynamoDB tables and GSIs from current model schemas',
+    bootstrap: true,
+    run: async () => {
+      const config = (await import('stonyx/config')).default;
+
+      if (!config.orm.dynamodb) {
+        console.error('DynamoDB is not configured. Set DYNAMODB_REGION (and optionally DYNAMODB_ENDPOINT) to enable DynamoDB mode.');
+        process.exit(1);
+      }
+
+      const { default: DynamoDBDB } = await import('./dynamodb/dynamodb-db.js');
+      const db = new DynamoDBDB();
+      await db.init();
+      await db.startup();
+      await db.shutdown();
+      console.log('DynamoDB tables synced successfully.');
+    }
+  },
   'db:migrate': {
     description: 'Apply pending MySQL migrations',
     bootstrap: true,
     run: async () => {
       const config = (await import('stonyx/config')).default;
       const mysqlConfig = config.orm.mysql;
+
+      if (config.orm.dynamodb) {
+        console.log('DynamoDB does not use file-based migrations. Use db:sync to provision tables.');
+        return;
+      }
 
       if (!mysqlConfig) {
         console.error('MySQL is not configured. Set MYSQL_HOST to enable MySQL mode.');
@@ -92,6 +123,12 @@ const commands: Record<string, Command> = {
     bootstrap: true,
     run: async () => {
       const config = (await import('stonyx/config')).default;
+
+      if (config.orm.dynamodb) {
+        console.log('DynamoDB does not support migration rollback. Manage table changes via the AWS console or db:sync.');
+        return;
+      }
+
       const mysqlConfig = config.orm.mysql;
 
       if (!mysqlConfig) {
@@ -138,6 +175,12 @@ const commands: Record<string, Command> = {
     bootstrap: true,
     run: async () => {
       const config = (await import('stonyx/config')).default;
+
+      if (config.orm.dynamodb) {
+        console.log('DynamoDB does not use file-based migrations. Use db:sync to provision tables.');
+        return;
+      }
+
       const mysqlConfig = config.orm.mysql;
 
       if (!mysqlConfig) {

--- a/src/dynamodb/connection.ts
+++ b/src/dynamodb/connection.ts
@@ -1,0 +1,49 @@
+/**
+ * DynamoDB connection factory.
+ *
+ * Dynamically imports @aws-sdk/client-dynamodb and @aws-sdk/lib-dynamodb
+ * so these are optional peerDependencies (matching the pg/mysql2 pattern).
+ */
+
+export interface DynamoDBConfig {
+  region?: string;
+  endpoint?: string;
+  [key: string]: unknown;
+}
+
+// Type aliases — declared loose so we don't need to import the real SDK types
+// at compile time (they're optional peer deps).
+export type DocumentClient = {
+  send(command: unknown): Promise<unknown>;
+};
+
+export type DocumentClientConstructor = new (options: { client: unknown }) => DocumentClient;
+export type DynamoDBClientConstructor = new (options: unknown) => unknown;
+
+/**
+ * Create a DynamoDBDocumentClient from the given config.
+ * Uses dynamic import so @aws-sdk/* are optional peer deps.
+ */
+export async function createDocumentClient(dbConfig: DynamoDBConfig): Promise<DocumentClient> {
+  const { DynamoDB } = await import('@aws-sdk/client-dynamodb' as string) as {
+    DynamoDB: DynamoDBClientConstructor;
+  };
+  const { DynamoDBDocument } = await import('@aws-sdk/lib-dynamodb' as string) as {
+    DynamoDBDocument: DocumentClientConstructor;
+  };
+
+  const clientOptions: Record<string, unknown> = {};
+  if (dbConfig.region) clientOptions.region = dbConfig.region;
+  if (dbConfig.endpoint) clientOptions.endpoint = dbConfig.endpoint;
+
+  const rawClient = new DynamoDB(clientOptions);
+  return new DynamoDBDocument({ client: rawClient });
+}
+
+/**
+ * Nullify the document client reference (DynamoDB connections are HTTP-based
+ * and stateless — no explicit pool close needed, but we clear the reference).
+ */
+export function destroyDocumentClient(_client: DocumentClient | null): null {
+  return null;
+}

--- a/src/dynamodb/dynamodb-db.ts
+++ b/src/dynamodb/dynamodb-db.ts
@@ -133,7 +133,7 @@ export interface DynamoDBDeps {
   store: typeof store;
   getPluralName: typeof getPluralName;
   config: typeof config;
-  log: Record<string, ((...args: unknown[]) => void) | undefined>;
+  log: typeof log;
   /** Injected for testing — import('@stonyx/orm') replacement */
   _importOrm?: () => Promise<OrmModule>;
   [key: string]: unknown;
@@ -182,8 +182,9 @@ export default class DynamoDBDB {
   private _gsiRegistry: GsiRegistry = new Map();
 
   constructor(deps: Partial<DynamoDBDeps> = {}) {
-    if (DynamoDBDB.instance) return DynamoDBDB.instance;
-    DynamoDBDB.instance = this;
+    const Ctor = this.constructor as typeof DynamoDBDB;
+    if (Ctor.instance) return Ctor.instance;
+    Ctor.instance = this;
 
     this.deps = { ...defaultDeps, ...deps } as DynamoDBDeps;
     this.client = null;
@@ -744,7 +745,7 @@ export default class DynamoDBDB {
   // Private — store eviction
   // -------------------------------------------------------------------------
 
-  _evictIfNotMemory(modelName: string, record: OrmRecord): void {
+  private _evictIfNotMemory(modelName: string, record: OrmRecord): void {
     const storeRef = this.deps.store as {
       _memoryResolver?: (name: string) => boolean;
       get?: (name: string) => Map<unknown, unknown> | undefined;

--- a/src/dynamodb/dynamodb-db.ts
+++ b/src/dynamodb/dynamodb-db.ts
@@ -1,0 +1,767 @@
+/**
+ * DynamoDB driver implementing the SqlDb PAL contract.
+ *
+ * Drop-in replacement for PostgresDB / MysqlDB — zero ORM core changes.
+ * Selected via config.orm.dynamodb.
+ */
+
+import { createDocumentClient, destroyDocumentClient } from './connection.js';
+import type { DocumentClient, DynamoDBConfig } from './connection.js';
+import {
+  buildPutItem,
+  buildGetItem,
+  buildUpdateItem,
+  buildDeleteItem,
+  buildScan,
+  buildQuery,
+} from './operation-builder.js';
+import { introspectModels, getTopologicalOrder } from '../postgres/schema-introspector.js';
+import { getDynamoKeyType } from './type-map.js';
+import { store } from '@stonyx/orm';
+import { createRecord } from '../manage-record.js';
+import { getPluralName } from '../plural-registry.js';
+import { sanitizeTableName } from '../schema-helpers.js';
+import config from 'stonyx/config';
+import log from 'stonyx/log';
+import type { ModelSchema, OrmRecord } from '../types/orm-types.js';
+
+// ---------------------------------------------------------------------------
+// ULID — monotonic, inline implementation (avoids heavy dep)
+// ---------------------------------------------------------------------------
+
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+function generateUlid(): string {
+  const now = Date.now();
+  let id = '';
+
+  // 10-char timestamp (48-bit millisecond precision)
+  let t = now;
+  for (let i = 9; i >= 0; i--) {
+    id = CROCKFORD[t % 32] + id;
+    t = Math.floor(t / 32);
+  }
+
+  // 16-char random
+  for (let i = 0; i < 16; i++) {
+    id += CROCKFORD[Math.floor(Math.random() * 32)];
+  }
+
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// SDK Command factories (injectable for testing without real AWS SDK)
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the DynamoDB DocumentClient command constructors via dynamic import.
+ * Returns a frozen object so it can be cached in deps.
+ */
+export async function loadDocClientCommands(): Promise<{
+  PutCommand: new (params: unknown) => unknown;
+  GetCommand: new (params: unknown) => unknown;
+  UpdateCommand: new (params: unknown) => unknown;
+  DeleteCommand: new (params: unknown) => unknown;
+  ScanCommand: new (params: unknown) => unknown;
+  QueryCommand: new (params: unknown) => unknown;
+}> {
+  return import('@aws-sdk/lib-dynamodb' as string) as Promise<{
+    PutCommand: new (params: unknown) => unknown;
+    GetCommand: new (params: unknown) => unknown;
+    UpdateCommand: new (params: unknown) => unknown;
+    DeleteCommand: new (params: unknown) => unknown;
+    ScanCommand: new (params: unknown) => unknown;
+    QueryCommand: new (params: unknown) => unknown;
+  }>;
+}
+
+export async function loadTableCommands(): Promise<{
+  DynamoDBClient: new (opts: unknown) => { send(cmd: unknown): Promise<unknown> };
+  DescribeTableCommand: new (params: unknown) => unknown;
+  CreateTableCommand: new (params: unknown) => unknown;
+  UpdateTableCommand: new (params: unknown) => unknown;
+}> {
+  return import('@aws-sdk/client-dynamodb' as string) as Promise<{
+    DynamoDBClient: new (opts: unknown) => { send(cmd: unknown): Promise<unknown> };
+    DescribeTableCommand: new (params: unknown) => unknown;
+    CreateTableCommand: new (params: unknown) => unknown;
+    UpdateTableCommand: new (params: unknown) => unknown;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PersistContext {
+  record?: OrmRecord;
+  recordId?: unknown;
+  oldState?: Record<string, unknown>;
+  rawData?: Record<string, unknown>;
+}
+
+interface PersistResponse {
+  data?: { id?: unknown };
+}
+
+/** Minimal Orm module shape needed at runtime — avoids circular import at top-level. */
+interface OrmModule {
+  default: {
+    instance: {
+      getRecordClasses(name: string): { modelClass: { memory?: boolean } };
+      isView?(name: string): boolean;
+    };
+  };
+}
+
+export interface DynamoDBDeps {
+  createDocumentClient: typeof createDocumentClient;
+  destroyDocumentClient: typeof destroyDocumentClient;
+  loadDocClientCommands: typeof loadDocClientCommands;
+  loadTableCommands: typeof loadTableCommands;
+  buildPutItem: typeof buildPutItem;
+  buildGetItem: typeof buildGetItem;
+  buildUpdateItem: typeof buildUpdateItem;
+  buildDeleteItem: typeof buildDeleteItem;
+  buildScan: typeof buildScan;
+  buildQuery: typeof buildQuery;
+  introspectModels: typeof introspectModels;
+  getTopologicalOrder: typeof getTopologicalOrder;
+  getDynamoKeyType: typeof getDynamoKeyType;
+  createRecord: typeof createRecord;
+  store: typeof store;
+  getPluralName: typeof getPluralName;
+  config: typeof config;
+  log: Record<string, ((...args: unknown[]) => void) | undefined>;
+  /** Injected for testing — import('@stonyx/orm') replacement */
+  _importOrm?: () => Promise<OrmModule>;
+  [key: string]: unknown;
+}
+
+const defaultDeps: DynamoDBDeps = {
+  createDocumentClient,
+  destroyDocumentClient,
+  loadDocClientCommands,
+  loadTableCommands,
+  buildPutItem,
+  buildGetItem,
+  buildUpdateItem,
+  buildDeleteItem,
+  buildScan,
+  buildQuery,
+  introspectModels,
+  getTopologicalOrder,
+  getDynamoKeyType,
+  createRecord,
+  store,
+  getPluralName,
+  config,
+  log,
+};
+
+// ---------------------------------------------------------------------------
+// GSI registry type
+// ---------------------------------------------------------------------------
+
+/** modelName → attrName → gsiName */
+type GsiRegistry = Map<string, Map<string, string>>;
+
+// ---------------------------------------------------------------------------
+// DynamoDB driver
+// ---------------------------------------------------------------------------
+
+export default class DynamoDBDB {
+  static instance: DynamoDBDB | undefined;
+
+  deps!: DynamoDBDeps;
+  client!: DocumentClient | null;
+  dbConfig!: DynamoDBConfig;
+
+  /** GSI registry built during init from model introspection. */
+  private _gsiRegistry: GsiRegistry = new Map();
+
+  constructor(deps: Partial<DynamoDBDeps> = {}) {
+    if (DynamoDBDB.instance) return DynamoDBDB.instance;
+    DynamoDBDB.instance = this;
+
+    this.deps = { ...defaultDeps, ...deps } as DynamoDBDeps;
+    this.client = null;
+
+    const dynamoConfig = this.deps.config.orm.dynamodb;
+    if (!dynamoConfig) throw new Error('DynamoDB configuration (config.orm.dynamodb) is required');
+    this.dbConfig = dynamoConfig as DynamoDBConfig;
+  }
+
+  private requireClient(): DocumentClient {
+    if (!this.client) throw new Error('DynamoDBDB client not initialized — call init() first');
+    return this.client;
+  }
+
+  /** Resolve Orm singleton — falls back to real import in production. */
+  private async _getOrm(): Promise<OrmModule> {
+    if (this.deps._importOrm) return this.deps._importOrm();
+    return import('@stonyx/orm') as unknown as Promise<OrmModule>;
+  }
+
+  // -------------------------------------------------------------------------
+  // SqlDb contract — init
+  // -------------------------------------------------------------------------
+
+  async init(): Promise<void> {
+    this.client = await this.deps.createDocumentClient(this.dbConfig);
+    this._buildGsiRegistry();
+    await this.loadMemoryRecords();
+  }
+
+  // -------------------------------------------------------------------------
+  // SqlDb contract — startup (table provisioning)
+  // -------------------------------------------------------------------------
+
+  /**
+   * For each model, DescribeTable — CreateTable if missing (with GSIs, PAY_PER_REQUEST).
+   * For existing tables, check for missing GSIs and UpdateTable + poll for ACTIVE.
+   */
+  async startup(): Promise<void> {
+    const schemas = this.deps.introspectModels();
+    const { DynamoDBClient, DescribeTableCommand, CreateTableCommand, UpdateTableCommand } =
+      await this.deps.loadTableCommands();
+
+    const clientOptions: Record<string, unknown> = {};
+    if (this.dbConfig.region) clientOptions.region = this.dbConfig.region;
+    if (this.dbConfig.endpoint) clientOptions.endpoint = this.dbConfig.endpoint;
+
+    const rawClient = new DynamoDBClient(clientOptions);
+
+    for (const [modelName, schema] of Object.entries(schemas)) {
+      const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+      const gsis = this._buildGsiDefinitions(modelName, schema);
+
+      try {
+        const desc = await rawClient.send(new DescribeTableCommand({ TableName: tableName })) as {
+          Table?: { TableStatus?: string; GlobalSecondaryIndexes?: Array<{ IndexName?: string }> };
+        };
+
+        // Table exists — check for missing GSIs
+        const existingGsiNames = new Set(
+          (desc.Table?.GlobalSecondaryIndexes ?? []).map((g: { IndexName?: string }) => g.IndexName ?? '')
+        );
+
+        for (const gsi of gsis) {
+          const gsiName = (gsi as { IndexName?: string }).IndexName;
+          if (gsiName && !existingGsiNames.has(gsiName)) {
+            this.deps.log.db?.(`Adding missing GSI '${gsiName}' to table '${tableName}'`);
+
+            await rawClient.send(new UpdateTableCommand({
+              TableName: tableName,
+              GlobalSecondaryIndexUpdates: [{ Create: gsi }],
+              AttributeDefinitions: this._buildAttributeDefinitions(schema),
+            }));
+
+            await this._waitForTableActive(rawClient, tableName, DescribeTableCommand);
+          }
+        }
+
+        this.deps.log.db?.(`DynamoDB table '${tableName}' is ready`);
+      } catch (err: unknown) {
+        const code = (err as { name?: string }).name;
+        if (code !== 'ResourceNotFoundException') throw err;
+
+        // Table does not exist — create it
+        this.deps.log.db?.(`Creating DynamoDB table '${tableName}'`);
+
+        await rawClient.send(new CreateTableCommand({
+          TableName: tableName,
+          BillingMode: 'PAY_PER_REQUEST',
+          AttributeDefinitions: this._buildAttributeDefinitions(schema),
+          KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
+          ...(gsis.length > 0 ? { GlobalSecondaryIndexes: gsis } : {}),
+        }));
+
+        await this._waitForTableActive(rawClient, tableName, DescribeTableCommand);
+        this.deps.log.db?.(`Created DynamoDB table '${tableName}'`);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // SqlDb contract — shutdown
+  // -------------------------------------------------------------------------
+
+  async shutdown(): Promise<void> {
+    this.client = this.deps.destroyDocumentClient(this.client);
+  }
+
+  // -------------------------------------------------------------------------
+  // SqlDb contract — persist
+  // -------------------------------------------------------------------------
+
+  async persist(operation: string, modelName: string, context: PersistContext, response: PersistResponse): Promise<void> {
+    const OrmModule = await this._getOrm();
+    if (OrmModule.default?.instance?.isView?.(modelName)) return;
+
+    switch (operation) {
+      case 'create':
+        return this._persistCreate(modelName, context, response);
+      case 'update':
+        return this._persistUpdate(modelName, context);
+      case 'delete':
+        return this._persistDelete(modelName, context);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // SqlDb contract — findRecord
+  // -------------------------------------------------------------------------
+
+  async findRecord(modelName: string, id: unknown): Promise<OrmRecord | undefined> {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+    if (!schema) return undefined;
+
+    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const { GetCommand } = await this.deps.loadDocClientCommands();
+
+    const params = this.deps.buildGetItem(tableName, { id });
+
+    try {
+      const result = await this.requireClient().send(new GetCommand(params)) as {
+        Item?: Record<string, unknown>;
+      };
+
+      if (!result.Item) return undefined;
+
+      const rawData = this._itemToRawData(result.Item, schema);
+      const record = this.deps.createRecord(modelName, rawData, {
+        isDbRecord: true, serialize: false, transform: false,
+      }) as unknown as OrmRecord;
+
+      this._evictIfNotMemory(modelName, record);
+      return record;
+    } catch (err: unknown) {
+      if ((err as { name?: string }).name === 'ResourceNotFoundException') return undefined;
+      throw err;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // SqlDb contract — findAll
+  // -------------------------------------------------------------------------
+
+  async findAll(modelName: string, conditions?: Record<string, unknown>): Promise<OrmRecord[]> {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+    if (!schema) return [];
+
+    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+
+    try {
+      let items: Record<string, unknown>[];
+
+      if (!conditions || Object.keys(conditions).length === 0) {
+        items = await this._paginatedScan(tableName);
+      } else {
+        // Try to route through a GSI if one matches a condition key
+        const gsiMatch = this._findGsiMatch(modelName, conditions);
+
+        if (gsiMatch) {
+          const { indexName, keyConditions, remainingConditions } = gsiMatch;
+          items = await this._paginatedQuery(tableName, indexName, keyConditions);
+
+          // Filter remaining non-key conditions in memory
+          if (Object.keys(remainingConditions).length > 0) {
+            items = items.filter(item =>
+              Object.entries(remainingConditions).every(([k, v]) => item[k] === v)
+            );
+          }
+        } else {
+          // No GSI — fall back to Scan + FilterExpression (warn)
+          this.deps.log.warn?.(
+            `[DynamoDB] findAll('${modelName}') using Scan+FilterExpression — no GSI for conditions: ${JSON.stringify(conditions)}. Add a GSI index for better performance.`
+          );
+          items = await this._paginatedScan(tableName, conditions);
+        }
+      }
+
+      const records = items.map(item => {
+        const rawData = this._itemToRawData(item, schema);
+        return this.deps.createRecord(modelName, rawData, {
+          isDbRecord: true, serialize: false, transform: false,
+        }) as unknown as OrmRecord;
+      });
+
+      for (const record of records) {
+        this._evictIfNotMemory(modelName, record);
+      }
+
+      return records;
+    } catch (err: unknown) {
+      if ((err as { name?: string }).name === 'ResourceNotFoundException') return [];
+      throw err;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // loadMemoryRecords
+  // -------------------------------------------------------------------------
+
+  async loadMemoryRecords(): Promise<void> {
+    const schemas = this.deps.introspectModels();
+    const order = this.deps.getTopologicalOrder(schemas);
+    const OrmModule = await this._getOrm();
+    const Orm = OrmModule.default;
+
+    for (const modelName of order) {
+      const { modelClass } = Orm.instance.getRecordClasses(modelName);
+
+      if (modelClass?.memory === false) {
+        this.deps.log.db?.(`Skipping memory load for '${modelName}' (memory: false)`);
+        continue;
+      }
+
+      const schema = schemas[modelName];
+      const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+
+      try {
+        const items = await this._paginatedScan(tableName);
+
+        for (const item of items) {
+          const rawData = this._itemToRawData(item, schema);
+          this.deps.createRecord(modelName, rawData, {
+            isDbRecord: true, serialize: false, transform: false,
+          });
+        }
+      } catch (err: unknown) {
+        if ((err as { name?: string }).name === 'ResourceNotFoundException') {
+          this.deps.log.db?.(`Table '${tableName}' does not exist yet. Skipping load for '${modelName}'.`);
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — persist helpers
+  // -------------------------------------------------------------------------
+
+  private async _persistCreate(modelName: string, context: PersistContext, response: PersistResponse): Promise<void> {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+    if (!schema) return;
+
+    const recordId = response?.data?.id;
+    const storeRef = this.deps.store as unknown as { get(name: string, id: unknown): OrmRecord | null };
+    const record = recordId != null ? storeRef.get(modelName, recordId) : null;
+    if (!record) return;
+
+    const isPendingId = context.rawData?.__pendingSqlId === true;
+    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+
+    // For numeric-ID models with a pending ID, generate a ULID
+    let finalId: unknown = record.id;
+    if (isPendingId) {
+      finalId = generateUlid();
+    }
+
+    const item = this._recordToItem(record, schema, context.rawData);
+    item.id = finalId;
+
+    const { PutCommand } = await this.deps.loadDocClientCommands();
+    const params = this.deps.buildPutItem(tableName, item, 'attribute_not_exists(id)');
+    await this.requireClient().send(new PutCommand(params));
+
+    // Re-key the store record if we generated a new ID
+    if (isPendingId) {
+      const pendingId = record.id;
+      const modelStoreMap = (this.deps.store as unknown as { get(name: string): Map<unknown, unknown> }).get(modelName);
+      modelStoreMap.delete(pendingId);
+      record.__data.id = finalId as string | number;
+      record.id = finalId as string | number;
+      modelStoreMap.set(finalId as string | number, record);
+
+      if (response?.data) response.data.id = finalId;
+      delete record.__data.__pendingSqlId;
+    }
+  }
+
+  private async _persistUpdate(modelName: string, context: PersistContext): Promise<void> {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+    if (!schema) return;
+
+    const record = context.record;
+    if (!record) return;
+
+    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const id = record.id;
+    const oldState = context.oldState || {};
+    const currentData = record.__data;
+
+    // Build diff of changed columns
+    const changedData: Record<string, unknown> = {};
+
+    for (const col of Object.keys(schema.columns)) {
+      if (currentData[col] !== oldState[col]) {
+        changedData[col] = currentData[col] ?? null;
+      }
+    }
+
+    // FK changes
+    for (const fkCol of Object.keys(schema.foreignKeys)) {
+      const relName = fkCol.replace(/_id$/, '');
+      const relValue = record.__relationships[relName];
+      const currentFkValue = relValue && typeof relValue === 'object' && relValue !== null
+        ? (relValue as { id: unknown }).id ?? null
+        : relValue ?? record.__data[relName] ?? null;
+      const oldFkValue = oldState[relName] ?? null;
+
+      if (currentFkValue !== oldFkValue) changedData[fkCol] = currentFkValue;
+    }
+
+    if (Object.keys(changedData).length === 0) return;
+
+    const { UpdateCommand } = await this.deps.loadDocClientCommands();
+    const params = this.deps.buildUpdateItem(tableName, { id }, changedData);
+    await this.requireClient().send(new UpdateCommand(params));
+  }
+
+  private async _persistDelete(modelName: string, context: PersistContext): Promise<void> {
+    const schemas = this.deps.introspectModels();
+    const schema = schemas[modelName];
+    if (!schema) return;
+
+    const id = context.recordId;
+    if (id == null) return;
+
+    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const { DeleteCommand } = await this.deps.loadDocClientCommands();
+    const params = this.deps.buildDeleteItem(tableName, { id });
+    await this.requireClient().send(new DeleteCommand(params));
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — pagination helpers
+  // -------------------------------------------------------------------------
+
+  private async _paginatedScan(tableName: string, conditions?: Record<string, unknown>): Promise<Record<string, unknown>[]> {
+    const { ScanCommand } = await this.deps.loadDocClientCommands();
+    const items: Record<string, unknown>[] = [];
+    let lastKey: Record<string, unknown> | undefined;
+
+    do {
+      const params = this.deps.buildScan(tableName, conditions, lastKey);
+      const result = await this.requireClient().send(new ScanCommand(params)) as {
+        Items?: Record<string, unknown>[];
+        LastEvaluatedKey?: Record<string, unknown>;
+      };
+
+      if (result.Items) items.push(...result.Items);
+      lastKey = result.LastEvaluatedKey;
+    } while (lastKey);
+
+    return items;
+  }
+
+  private async _paginatedQuery(tableName: string, indexName: string, keyConditions: Record<string, unknown>): Promise<Record<string, unknown>[]> {
+    const { QueryCommand } = await this.deps.loadDocClientCommands();
+    const items: Record<string, unknown>[] = [];
+    let lastKey: Record<string, unknown> | undefined;
+
+    do {
+      const params = this.deps.buildQuery(tableName, indexName, keyConditions, lastKey);
+      const result = await this.requireClient().send(new QueryCommand(params)) as {
+        Items?: Record<string, unknown>[];
+        LastEvaluatedKey?: Record<string, unknown>;
+      };
+
+      if (result.Items) items.push(...result.Items);
+      lastKey = result.LastEvaluatedKey;
+    } while (lastKey);
+
+    return items;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — GSI registry
+  // -------------------------------------------------------------------------
+
+  /**
+   * Build the GSI registry from model introspection.
+   * Registry: modelName → attrName → gsiName
+   *
+   * FK columns (belonging to belongsTo relationships) get a GSI automatically.
+   */
+  private _buildGsiRegistry(): void {
+    const schemas = this.deps.introspectModels();
+
+    for (const [modelName, schema] of Object.entries(schemas)) {
+      const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+      const modelGsis = new Map<string, string>();
+
+      for (const fkCol of Object.keys(schema.foreignKeys)) {
+        const gsiName = `${tableName}-${fkCol}-index`;
+        modelGsis.set(fkCol, gsiName);
+      }
+
+      this._gsiRegistry.set(modelName, modelGsis);
+    }
+  }
+
+  /**
+   * Find a GSI that can serve the given conditions.
+   */
+  private _findGsiMatch(modelName: string, conditions: Record<string, unknown>): {
+    indexName: string;
+    keyConditions: Record<string, unknown>;
+    remainingConditions: Record<string, unknown>;
+  } | null {
+    const modelGsis = this._gsiRegistry.get(modelName);
+    if (!modelGsis) return null;
+
+    for (const [attrName, indexName] of modelGsis) {
+      if (conditions[attrName] !== undefined) {
+        const keyConditions: Record<string, unknown> = { [attrName]: conditions[attrName] };
+        const remainingConditions: Record<string, unknown> = {};
+
+        for (const [k, v] of Object.entries(conditions)) {
+          if (k !== attrName) remainingConditions[k] = v;
+        }
+
+        return { indexName, keyConditions, remainingConditions };
+      }
+    }
+
+    return null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — table provisioning helpers
+  // -------------------------------------------------------------------------
+
+  private _buildAttributeDefinitions(schema: ModelSchema): Array<{ AttributeName: string; AttributeType: string }> {
+    const defs: Array<{ AttributeName: string; AttributeType: string }> = [
+      { AttributeName: 'id', AttributeType: this.deps.getDynamoKeyType(schema.idType) },
+    ];
+
+    for (const fkCol of Object.keys(schema.foreignKeys)) {
+      defs.push({ AttributeName: fkCol, AttributeType: 'S' });
+    }
+
+    // Deduplicate
+    const seen = new Set<string>();
+    return defs.filter(d => {
+      if (seen.has(d.AttributeName)) return false;
+      seen.add(d.AttributeName);
+      return true;
+    });
+  }
+
+  private _buildGsiDefinitions(modelName: string, schema: ModelSchema): unknown[] {
+    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const gsis: unknown[] = [];
+
+    for (const fkCol of Object.keys(schema.foreignKeys)) {
+      const gsiName = `${tableName}-${fkCol}-index`;
+      gsis.push({
+        IndexName: gsiName,
+        KeySchema: [{ AttributeName: fkCol, KeyType: 'HASH' }],
+        Projection: { ProjectionType: 'ALL' },
+      });
+    }
+
+    return gsis;
+  }
+
+  private async _waitForTableActive(
+    rawClient: { send(cmd: unknown): Promise<unknown> },
+    tableName: string,
+    DescribeTableCommand: new (p: unknown) => unknown,
+  ): Promise<void> {
+    const MAX_POLLS = 60;
+    const POLL_INTERVAL = 2000;
+
+    for (let i = 0; i < MAX_POLLS; i++) {
+      const desc = await rawClient.send(new DescribeTableCommand({ TableName: tableName })) as {
+        Table?: { TableStatus?: string };
+      };
+
+      if (desc.Table?.TableStatus === 'ACTIVE') return;
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
+    }
+
+    throw new Error(`DynamoDB table '${tableName}' did not become ACTIVE within ${MAX_POLLS * POLL_INTERVAL / 1000}s`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — data conversion
+  // -------------------------------------------------------------------------
+
+  private _itemToRawData(item: Record<string, unknown>, schema: ModelSchema): Record<string, unknown> {
+    const rawData: Record<string, unknown> = { ...item };
+
+    // Map FK columns back to relationship keys (matching PostgresDB pattern)
+    for (const [fkCol] of Object.entries(schema.foreignKeys)) {
+      const relName = fkCol.replace(/_id$/, '');
+      if (rawData[fkCol] !== undefined) {
+        rawData[relName] = rawData[fkCol];
+        delete rawData[fkCol];
+      }
+    }
+
+    return rawData;
+  }
+
+  private _recordToItem(record: OrmRecord, schema: ModelSchema, rawData?: Record<string, unknown>): Record<string, unknown> {
+    const item: Record<string, unknown> = {};
+    const data = record.__data;
+
+    if (data.id !== undefined) item.id = data.id;
+
+    for (const col of Object.keys(schema.columns)) {
+      if (data[col] !== undefined) item[col] = data[col];
+    }
+
+    for (const fkCol of Object.keys(schema.foreignKeys)) {
+      const relName = fkCol.replace(/_id$/, '');
+      const related = record.__relationships[relName];
+
+      if (related && typeof related === 'object' && related !== null) {
+        item[fkCol] = (related as { id: unknown }).id;
+      } else if (related != null) {
+        item[fkCol] = related;
+      } else if (data[relName] !== undefined) {
+        item[fkCol] = data[relName];
+      } else if (rawData?.[relName] !== undefined) {
+        item[fkCol] = rawData[relName];
+      }
+    }
+
+    return item;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private — store eviction
+  // -------------------------------------------------------------------------
+
+  _evictIfNotMemory(modelName: string, record: OrmRecord): void {
+    const storeRef = this.deps.store as {
+      _memoryResolver?: (name: string) => boolean;
+      get?: (name: string) => Map<unknown, unknown> | undefined;
+      data?: { get(name: string): Map<unknown, unknown> | undefined };
+    };
+
+    if (storeRef._memoryResolver && !storeRef._memoryResolver(modelName)) {
+      const modelStore = storeRef.get?.(modelName) ?? storeRef.data?.get(modelName);
+      if (modelStore) modelStore.delete(record.id);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Deprecated alias
+  // -------------------------------------------------------------------------
+
+  async loadAllRecords(): Promise<void> {
+    return this.loadMemoryRecords();
+  }
+}

--- a/src/dynamodb/operation-builder.ts
+++ b/src/dynamodb/operation-builder.ts
@@ -1,0 +1,188 @@
+/**
+ * DynamoDB operation parameter builders.
+ *
+ * Each function returns a plain-object "params" bag that can be passed
+ * directly to the corresponding DocumentClient command
+ * (PutCommand, GetCommand, UpdateCommand, DeleteCommand, ScanCommand, QueryCommand).
+ *
+ * All functions are pure — no SDK imports here; the caller wraps params
+ * in the appropriate Command class.
+ */
+
+export interface PutItemParams {
+  TableName: string;
+  Item: Record<string, unknown>;
+  ConditionExpression?: string;
+}
+
+export interface GetItemParams {
+  TableName: string;
+  Key: Record<string, unknown>;
+}
+
+export interface UpdateItemParams {
+  TableName: string;
+  Key: Record<string, unknown>;
+  UpdateExpression: string;
+  ExpressionAttributeNames: Record<string, string>;
+  ExpressionAttributeValues: Record<string, unknown>;
+  ReturnValues: string;
+}
+
+export interface DeleteItemParams {
+  TableName: string;
+  Key: Record<string, unknown>;
+}
+
+export interface ScanParams {
+  TableName: string;
+  FilterExpression?: string;
+  ExpressionAttributeNames?: Record<string, string>;
+  ExpressionAttributeValues?: Record<string, unknown>;
+  ExclusiveStartKey?: Record<string, unknown>;
+}
+
+export interface QueryParams {
+  TableName: string;
+  IndexName: string;
+  KeyConditionExpression: string;
+  ExpressionAttributeNames: Record<string, string>;
+  ExpressionAttributeValues: Record<string, unknown>;
+  ExclusiveStartKey?: Record<string, unknown>;
+}
+
+/**
+ * PutItem — optionally with a condition expression.
+ *
+ * Pass conditionExpression = 'attribute_not_exists(id)' to enforce uniqueness.
+ */
+export function buildPutItem(
+  tableName: string,
+  item: Record<string, unknown>,
+  conditionExpression?: string,
+): PutItemParams {
+  const params: PutItemParams = { TableName: tableName, Item: item };
+  if (conditionExpression) params.ConditionExpression = conditionExpression;
+  return params;
+}
+
+/**
+ * GetItem by primary key.
+ */
+export function buildGetItem(
+  tableName: string,
+  key: Record<string, unknown>,
+): GetItemParams {
+  return { TableName: tableName, Key: key };
+}
+
+/**
+ * UpdateItem with a SET expression built from the `updates` object.
+ * Only the supplied attributes are updated (diff-based call site).
+ */
+export function buildUpdateItem(
+  tableName: string,
+  key: Record<string, unknown>,
+  updates: Record<string, unknown>,
+): UpdateItemParams {
+  const names: Record<string, string> = {};
+  const values: Record<string, unknown> = {};
+  const setClauses: string[] = [];
+
+  for (const [attr, val] of Object.entries(updates)) {
+    const nameAlias = `#${attr}`;
+    const valAlias = `:${attr}`;
+    names[nameAlias] = attr;
+    values[valAlias] = val;
+    setClauses.push(`${nameAlias} = ${valAlias}`);
+  }
+
+  return {
+    TableName: tableName,
+    Key: key,
+    UpdateExpression: `SET ${setClauses.join(', ')}`,
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: values,
+    ReturnValues: 'NONE',
+  };
+}
+
+/**
+ * DeleteItem by primary key.
+ */
+export function buildDeleteItem(
+  tableName: string,
+  key: Record<string, unknown>,
+): DeleteItemParams {
+  return { TableName: tableName, Key: key };
+}
+
+/**
+ * ScanCommand params.
+ * If conditions are supplied they are rendered as a FilterExpression using AND.
+ */
+export function buildScan(
+  tableName: string,
+  conditions?: Record<string, unknown>,
+  exclusiveStartKey?: Record<string, unknown>,
+): ScanParams {
+  const params: ScanParams = { TableName: tableName };
+
+  if (exclusiveStartKey) params.ExclusiveStartKey = exclusiveStartKey;
+
+  if (conditions && Object.keys(conditions).length > 0) {
+    const names: Record<string, string> = {};
+    const values: Record<string, unknown> = {};
+    const clauses: string[] = [];
+
+    for (const [attr, val] of Object.entries(conditions)) {
+      const nameAlias = `#${attr}`;
+      const valAlias = `:${attr}`;
+      names[nameAlias] = attr;
+      values[valAlias] = val;
+      clauses.push(`${nameAlias} = ${valAlias}`);
+    }
+
+    params.FilterExpression = clauses.join(' AND ');
+    params.ExpressionAttributeNames = names;
+    params.ExpressionAttributeValues = values;
+  }
+
+  return params;
+}
+
+/**
+ * QueryCommand params for a GSI.
+ * keyConditions must be in the form { attrName: value } and will be rendered
+ * as equality expressions joined by AND.
+ */
+export function buildQuery(
+  tableName: string,
+  indexName: string,
+  keyConditions: Record<string, unknown>,
+  exclusiveStartKey?: Record<string, unknown>,
+): QueryParams {
+  const names: Record<string, string> = {};
+  const values: Record<string, unknown> = {};
+  const clauses: string[] = [];
+
+  for (const [attr, val] of Object.entries(keyConditions)) {
+    const nameAlias = `#${attr}`;
+    const valAlias = `:${attr}`;
+    names[nameAlias] = attr;
+    values[valAlias] = val;
+    clauses.push(`${nameAlias} = ${valAlias}`);
+  }
+
+  const params: QueryParams = {
+    TableName: tableName,
+    IndexName: indexName,
+    KeyConditionExpression: clauses.join(' AND '),
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: values,
+  };
+
+  if (exclusiveStartKey) params.ExclusiveStartKey = exclusiveStartKey;
+
+  return params;
+}

--- a/src/dynamodb/type-map.ts
+++ b/src/dynamodb/type-map.ts
@@ -1,0 +1,54 @@
+/**
+ * Maps ORM attribute types to DynamoDB scalar attribute types.
+ * DynamoDB DocumentClient auto-marshalls JS objects, so most values
+ * are sent as their native JS types.  This map is used by the
+ * schema-introspector and startup provisioner for table/GSI creation.
+ */
+
+export type DynamoScalarType = 'S' | 'N' | 'BOOL';
+
+/**
+ * DynamoDB attribute-type string for a given ORM attr type.
+ * - string            → S
+ * - number / float    → N  (stored as Number; DocumentClient handles it)
+ * - boolean           → BOOL
+ * - date              → S  (ISO-8601 string — enables range queries)
+ * - timestamp         → N  (milliseconds since epoch)
+ * - passthrough/trim/etc → S  (safe default)
+ *
+ * For key schema declarations only `S` and `N` are valid; BOOL
+ * is legal for attributes but never for a PK/SK.
+ */
+const typeMap: Record<string, DynamoScalarType> = {
+  string: 'S',
+  number: 'N',
+  float: 'N',
+  boolean: 'BOOL',
+  date: 'S',
+  timestamp: 'N',
+  passthrough: 'S',
+  trim: 'S',
+  uppercase: 'S',
+  ceil: 'N',
+  floor: 'N',
+  round: 'N',
+};
+
+/**
+ * Returns the DynamoDB attribute type for a given ORM type string.
+ * Defaults to 'S' for any unknown/custom type.
+ */
+export function getDynamoType(attrType: string): DynamoScalarType {
+  return typeMap[attrType] ?? 'S';
+}
+
+/**
+ * Returns the DynamoDB key type ('S' | 'N') for use in KeySchema.
+ * BOOL cannot be a key attribute; anything that maps to BOOL falls back to 'S'.
+ */
+export function getDynamoKeyType(attrType: string): 'S' | 'N' {
+  const t = getDynamoType(attrType);
+  return t === 'N' ? 'N' : 'S';
+}
+
+export default typeMap;

--- a/src/main.ts
+++ b/src/main.ts
@@ -164,6 +164,11 @@ export default class Orm {
       this.sqlDb = new MysqlDB() as SqlDb;
       this.db = this.sqlDb;
       promises.push(this.sqlDb.init());
+    } else if (config.orm.dynamodb) {
+      const { default: DynamoDBDB } = await import('./dynamodb/dynamodb-db.js');
+      this.sqlDb = new DynamoDBDB() as SqlDb;
+      this.db = this.sqlDb;
+      promises.push(this.sqlDb.init());
     } else if (this.options.dbType !== 'none') {
       const db = new DB();
       this.db = db;

--- a/src/types/orm-types.ts
+++ b/src/types/orm-types.ts
@@ -48,6 +48,12 @@ export interface OrmRestServerConfig {
   metaRoute: boolean;
 }
 
+export interface OrmDynamoDBConfig {
+  region?: string;
+  endpoint?: string;
+  [key: string]: unknown;
+}
+
 export interface OrmSection {
   db: OrmDbConfig;
   paths: OrmPaths;
@@ -55,6 +61,7 @@ export interface OrmSection {
   mysql?: OrmMysqlConfig;
   postgres?: OrmPostgresConfig;
   timescale?: OrmPostgresConfig;
+  dynamodb?: OrmDynamoDBConfig;
   logColor?: string;
   logMethod?: string;
   [key: string]: unknown;

--- a/test/helpers/dynamodb-test-helper.ts
+++ b/test/helpers/dynamodb-test-helper.ts
@@ -1,0 +1,95 @@
+// test/helpers/dynamodb-test-helper.ts
+import sinon from 'sinon';
+import DynamoDBDB from '../../src/dynamodb/dynamodb-db.js';
+import type { DynamoDBDeps } from '../../src/dynamodb/dynamodb-db.js';
+
+/** Command stub factory — returns a class whose instances can be passed to send(). */
+export function makeCommandStub(name: string) {
+  function Cmd(this: { params: unknown }, params: unknown) { this.params = params; }
+  Cmd.displayName = name;
+  return Cmd as unknown as new (params: unknown) => unknown;
+}
+
+/** Build a stub loadDocClientCommands dep that resolves to no-op command stubs. */
+export function makeDocClientCommands() {
+  return {
+    PutCommand: makeCommandStub('PutCommand'),
+    GetCommand: makeCommandStub('GetCommand'),
+    UpdateCommand: makeCommandStub('UpdateCommand'),
+    DeleteCommand: makeCommandStub('DeleteCommand'),
+    ScanCommand: makeCommandStub('ScanCommand'),
+    QueryCommand: makeCommandStub('QueryCommand'),
+  };
+}
+
+export function createMockDeps(overrides: Partial<DynamoDBDeps> = {}): DynamoDBDeps {
+  const docCommands = makeDocClientCommands();
+
+  return {
+    createDocumentClient: sinon.stub().resolves({ send: sinon.stub().resolves({}) }),
+    destroyDocumentClient: sinon.stub().returns(null),
+    loadDocClientCommands: sinon.stub().resolves(docCommands),
+    loadTableCommands: sinon.stub().resolves({
+      DynamoDBClient: function(this: { send: sinon.SinonStub }) {
+        this.send = sinon.stub().resolves({ Table: { TableStatus: 'ACTIVE', GlobalSecondaryIndexes: [] } });
+      },
+      DescribeTableCommand: makeCommandStub('DescribeTableCommand'),
+      CreateTableCommand: makeCommandStub('CreateTableCommand'),
+      UpdateTableCommand: makeCommandStub('UpdateTableCommand'),
+    }),
+    buildPutItem: sinon.stub().returns({ TableName: 'test', Item: {} }),
+    buildGetItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
+    buildUpdateItem: sinon.stub().returns({ TableName: 'test', Key: {}, UpdateExpression: 'SET #x = :x', ExpressionAttributeNames: {}, ExpressionAttributeValues: {}, ReturnValues: 'NONE' }),
+    buildDeleteItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
+    buildScan: sinon.stub().returns({ TableName: 'test' }),
+    buildQuery: sinon.stub().returns({ TableName: 'test', IndexName: 'idx', KeyConditionExpression: '#id = :id', ExpressionAttributeNames: {}, ExpressionAttributeValues: {} }),
+    introspectModels: sinon.stub().returns({}),
+    getTopologicalOrder: sinon.stub().returns([]),
+    getDynamoKeyType: sinon.stub().returns('S'),
+    createRecord: sinon.stub().callsFake((name: string, data: Record<string, unknown>) => ({
+      id: data['id'],
+      __model: { __name: name },
+      __data: { ...data },
+      __relationships: {},
+    })),
+    store: { get: sinon.stub(), _memoryResolver: null } as unknown as DynamoDBDeps['store'],
+    getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
+    config: {
+      rootPath: '/app',
+      orm: {
+        dynamodb: { region: 'us-east-1' }
+      }
+    } as DynamoDBDeps['config'],
+    log: {
+      db: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+    } as unknown as DynamoDBDeps['log'],
+    _importOrm: sinon.stub().resolves({
+      default: {
+        instance: {
+          getRecordClasses(_name: string) {
+            return { modelClass: { memory: true } };
+          },
+          isView() { return false; }
+        }
+      }
+    }),
+    ...overrides,
+  } as DynamoDBDeps;
+}
+
+/** Reset the DynamoDBDB singleton between tests. */
+export function resetInstance() {
+  DynamoDBDB.instance = undefined;
+}
+
+/** Build a DynamoDBDB with a pre-wired mock client. */
+export function buildDb(deps: DynamoDBDeps) {
+  const db = new DynamoDBDB(deps);
+  const mockClient = {
+    send: sinon.stub().resolves({ Items: [], LastEvaluatedKey: undefined }),
+  };
+  db.client = mockClient;
+  return { db, mockClient };
+}

--- a/test/unit/commands-test.ts
+++ b/test/unit/commands-test.ts
@@ -1,4 +1,5 @@
 import QUnit from 'qunit';
+import sinon from 'sinon';
 
 const { module, test } = QUnit;
 
@@ -72,5 +73,97 @@ module('[Unit] ORM Commands', function() {
     assert.ok(cmd.description.length > 0, 'description is not empty');
     assert.equal(cmd.bootstrap, true, 'requires bootstrap');
     assert.equal(typeof cmd.run, 'function', 'has run function');
+  });
+
+  test('db:sync command exists and has required properties', async function(assert) {
+    const { default: commands } = await import('../../src/commands.js');
+    const cmd = commands['db:sync'];
+
+    assert.ok(cmd, 'has db:sync command');
+    assert.equal(typeof cmd.description, 'string', 'has description');
+    assert.ok(cmd.description.length > 0, 'description is not empty');
+    assert.equal(cmd.bootstrap, true, 'requires bootstrap');
+    assert.equal(typeof cmd.run, 'function', 'has run function');
+    assert.ok(cmd.description.toLowerCase().includes('dynamodb'), 'description mentions DynamoDB');
+  });
+});
+
+module('[Unit] ORM Commands — DynamoDB branching', function(hooks) {
+  let logStub: sinon.SinonStub;
+  let errorStub: sinon.SinonStub;
+
+  hooks.beforeEach(function() {
+    logStub = sinon.stub(console, 'log');
+    errorStub = sinon.stub(console, 'error');
+  });
+
+  hooks.afterEach(function() {
+    sinon.restore();
+  });
+
+  test('db:generate-migration prints DynamoDB message when dynamodb config present', async function(assert) {
+    // Stub stonyx/config to simulate DynamoDB mode
+    const configModule = await import('stonyx/config');
+    const originalOrm = (configModule.default as Record<string, unknown>).orm;
+    (configModule.default as Record<string, unknown>).orm = { dynamodb: { region: 'us-east-1' } };
+
+    try {
+      const { default: commands } = await import('../../src/commands.js');
+      await commands['db:generate-migration']!.run([]);
+
+      assert.ok(logStub.calledOnce, 'console.log called once');
+      assert.ok(logStub.firstCall.args[0].includes('DynamoDB'), 'message mentions DynamoDB');
+      assert.ok(logStub.firstCall.args[0].includes('db:sync'), 'message mentions db:sync');
+    } finally {
+      (configModule.default as Record<string, unknown>).orm = originalOrm;
+    }
+  });
+
+  test('db:migrate prints DynamoDB message when dynamodb config present', async function(assert) {
+    const configModule = await import('stonyx/config');
+    const originalOrm = (configModule.default as Record<string, unknown>).orm;
+    (configModule.default as Record<string, unknown>).orm = { dynamodb: { region: 'us-east-1' } };
+
+    try {
+      const { default: commands } = await import('../../src/commands.js');
+      await commands['db:migrate']!.run([]);
+
+      assert.ok(logStub.calledOnce, 'console.log called once');
+      assert.ok(logStub.firstCall.args[0].includes('DynamoDB'), 'message mentions DynamoDB');
+    } finally {
+      (configModule.default as Record<string, unknown>).orm = originalOrm;
+    }
+  });
+
+  test('db:migrate:rollback prints DynamoDB message when dynamodb config present', async function(assert) {
+    const configModule = await import('stonyx/config');
+    const originalOrm = (configModule.default as Record<string, unknown>).orm;
+    (configModule.default as Record<string, unknown>).orm = { dynamodb: { region: 'us-east-1' } };
+
+    try {
+      const { default: commands } = await import('../../src/commands.js');
+      await commands['db:migrate:rollback']!.run([]);
+
+      assert.ok(logStub.calledOnce, 'console.log called once');
+      assert.ok(logStub.firstCall.args[0].includes('DynamoDB'), 'message mentions DynamoDB');
+    } finally {
+      (configModule.default as Record<string, unknown>).orm = originalOrm;
+    }
+  });
+
+  test('db:migrate:status prints DynamoDB message when dynamodb config present', async function(assert) {
+    const configModule = await import('stonyx/config');
+    const originalOrm = (configModule.default as Record<string, unknown>).orm;
+    (configModule.default as Record<string, unknown>).orm = { dynamodb: { region: 'us-east-1' } };
+
+    try {
+      const { default: commands } = await import('../../src/commands.js');
+      await commands['db:migrate:status']!.run([]);
+
+      assert.ok(logStub.calledOnce, 'console.log called once');
+      assert.ok(logStub.firstCall.args[0].includes('DynamoDB'), 'message mentions DynamoDB');
+    } finally {
+      (configModule.default as Record<string, unknown>).orm = originalOrm;
+    }
   });
 });

--- a/test/unit/dynamodb/dynamodb-db-test.ts
+++ b/test/unit/dynamodb/dynamodb-db-test.ts
@@ -1,0 +1,448 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import DynamoDBDB from '../../../src/dynamodb/dynamodb-db.js';
+
+const { module, test } = QUnit;
+
+/** Command stub factory — returns a class whose instances can be passed to send(). */
+function makeCommandStub(name) {
+  function Cmd(params) { this.params = params; }
+  Cmd.displayName = name;
+  return Cmd;
+}
+
+/** Build a stub loadDocClientCommands dep that resolves to no-op command stubs. */
+function makeDocClientCommands() {
+  return {
+    PutCommand: makeCommandStub('PutCommand'),
+    GetCommand: makeCommandStub('GetCommand'),
+    UpdateCommand: makeCommandStub('UpdateCommand'),
+    DeleteCommand: makeCommandStub('DeleteCommand'),
+    ScanCommand: makeCommandStub('ScanCommand'),
+    QueryCommand: makeCommandStub('QueryCommand'),
+  };
+}
+
+function createMockDeps(overrides = {}) {
+  const docCommands = makeDocClientCommands();
+
+  return {
+    createDocumentClient: sinon.stub().resolves({ send: sinon.stub().resolves({}) }),
+    destroyDocumentClient: sinon.stub().returns(null),
+    loadDocClientCommands: sinon.stub().resolves(docCommands),
+    loadTableCommands: sinon.stub().resolves({
+      DynamoDBClient: function() { this.send = sinon.stub().resolves({ Table: { TableStatus: 'ACTIVE', GlobalSecondaryIndexes: [] } }); },
+      DescribeTableCommand: makeCommandStub('DescribeTableCommand'),
+      CreateTableCommand: makeCommandStub('CreateTableCommand'),
+      UpdateTableCommand: makeCommandStub('UpdateTableCommand'),
+    }),
+    buildPutItem: sinon.stub().returns({ TableName: 'test', Item: {} }),
+    buildGetItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
+    buildUpdateItem: sinon.stub().returns({ TableName: 'test', Key: {}, UpdateExpression: 'SET #x = :x', ExpressionAttributeNames: {}, ExpressionAttributeValues: {}, ReturnValues: 'NONE' }),
+    buildDeleteItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
+    buildScan: sinon.stub().returns({ TableName: 'test' }),
+    buildQuery: sinon.stub().returns({ TableName: 'test', IndexName: 'idx', KeyConditionExpression: '#id = :id', ExpressionAttributeNames: {}, ExpressionAttributeValues: {} }),
+    introspectModels: sinon.stub().returns({}),
+    getTopologicalOrder: sinon.stub().returns([]),
+    getDynamoKeyType: sinon.stub().returns('S'),
+    createRecord: sinon.stub().callsFake((name, data) => ({
+      id: data.id,
+      __model: { __name: name },
+      __data: { ...data },
+      __relationships: {},
+    })),
+    store: { get: sinon.stub(), _memoryResolver: null },
+    getPluralName: sinon.stub().callsFake(name => `${name}s`),
+    config: {
+      rootPath: '/app',
+      orm: {
+        dynamodb: { region: 'us-east-1' }
+      }
+    },
+    log: {
+      db: sinon.stub(),
+      warn: sinon.stub(),
+    },
+    _importOrm: sinon.stub().resolves({
+      default: {
+        instance: {
+          getRecordClasses(_name) {
+            return { modelClass: { memory: true } };
+          },
+          isView() { return false; }
+        }
+      }
+    }),
+    ...overrides,
+  };
+}
+
+// Reset singleton between tests
+function resetInstance() {
+  DynamoDBDB.instance = undefined;
+}
+
+// Build a DynamoDBDB with a pre-wired mock client
+function buildDb(deps) {
+  const db = new DynamoDBDB(deps);
+  const mockClient = {
+    send: sinon.stub().resolves({ Items: [], LastEvaluatedKey: undefined }),
+  };
+  db.client = mockClient;
+  return { db, mockClient };
+}
+
+module('[Unit] DynamoDBDB — constructor + singleton', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('creates singleton on first call', function(assert) {
+    const deps = createMockDeps();
+    const db1 = new DynamoDBDB(deps);
+    const db2 = new DynamoDBDB(deps);
+    assert.strictEqual(db1, db2, 'same instance returned on second call');
+  });
+
+  test('throws when dynamodb config missing', function(assert) {
+    const deps = createMockDeps({ config: { rootPath: '/app', orm: {} } });
+    assert.throws(
+      () => new DynamoDBDB(deps),
+      /DynamoDB configuration/,
+      'error thrown when dynamodb not configured'
+    );
+  });
+});
+
+module('[Unit] DynamoDBDB.init', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('calls createDocumentClient with config', async function(assert) {
+    const client = { send: sinon.stub().resolves({ Items: [] }) };
+    const deps = createMockDeps({
+      createDocumentClient: sinon.stub().resolves(client),
+    });
+
+    const db = new DynamoDBDB(deps);
+    await db.init();
+
+    assert.ok(deps.createDocumentClient.calledOnce, 'createDocumentClient called');
+    assert.deepEqual(deps.createDocumentClient.firstCall.args[0], { region: 'us-east-1' }, 'config passed');
+    assert.strictEqual(db.client, client, 'client set on instance');
+  });
+
+  test('calls loadMemoryRecords after client creation', async function(assert) {
+    const client = { send: sinon.stub().resolves({ Items: [] }) };
+    const deps = createMockDeps({
+      createDocumentClient: sinon.stub().resolves(client),
+    });
+
+    const db = new DynamoDBDB(deps);
+    const loadSpy = sinon.spy(db, 'loadMemoryRecords');
+    await db.init();
+
+    assert.ok(loadSpy.calledOnce, 'loadMemoryRecords called during init');
+  });
+});
+
+module('[Unit] DynamoDBDB.shutdown', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('nullifies the client', async function(assert) {
+    const deps = createMockDeps({
+      destroyDocumentClient: sinon.stub().returns(null),
+    });
+    const { db } = buildDb(deps);
+
+    await db.shutdown();
+
+    assert.strictEqual(db.client, null, 'client set to null after shutdown');
+    assert.ok(deps.destroyDocumentClient.calledOnce, 'destroyDocumentClient called');
+  });
+});
+
+module('[Unit] DynamoDBDB.findRecord', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('returns a record when GetItem returns an item', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'session': { table: 'sessions', columns: { token: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('sessions'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({ Item: { id: 'abc', token: 'tok123' } });
+
+    const record = await db.findRecord('session', 'abc');
+
+    assert.ok(deps.buildGetItem.calledOnce, 'buildGetItem called');
+    assert.ok(deps.createRecord.calledOnce, 'createRecord called');
+    assert.strictEqual(record.id, 'abc', 'record has correct id');
+  });
+
+  test('returns undefined when no item found', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'session': { table: 'sessions', columns: {}, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('sessions'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({ Item: undefined });
+
+    const record = await db.findRecord('session', 'missing');
+
+    assert.strictEqual(record, undefined, 'undefined returned for missing item');
+    assert.ok(deps.createRecord.notCalled, 'createRecord not called');
+  });
+
+  test('returns undefined for unknown model', async function(assert) {
+    const deps = createMockDeps({ introspectModels: sinon.stub().returns({}) });
+    const { db } = buildDb(deps);
+
+    const record = await db.findRecord('nonexistent', '1');
+    assert.strictEqual(record, undefined);
+    assert.ok(deps.buildGetItem.notCalled, 'no DynamoDB call made');
+  });
+
+  test('returns undefined on ResourceNotFoundException', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'session': { table: 'sessions', columns: {}, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('sessions'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    const err = Object.assign(new Error('No such table'), { name: 'ResourceNotFoundException' });
+    mockClient.send.rejects(err);
+
+    const record = await db.findRecord('session', '1');
+    assert.strictEqual(record, undefined, 'gracefully returns undefined');
+  });
+
+  test('FK columns are remapped to relationship keys', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'comment': {
+          table: 'comments',
+          columns: { body: 'S' },
+          foreignKeys: { post_id: { references: 'posts', column: 'id' } },
+          idType: 'string',
+        }
+      }),
+      getPluralName: sinon.stub().returns('comments'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({ Item: { id: 'c1', body: 'Hello', post_id: 'p1' } });
+
+    await db.findRecord('comment', 'c1');
+
+    const passedData = deps.createRecord.firstCall.args[1];
+    assert.strictEqual(passedData.post, 'p1', 'FK column remapped to relationship key');
+    assert.strictEqual(passedData.post_id, undefined, 'original FK column removed');
+  });
+});
+
+module('[Unit] DynamoDBDB.findAll', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('returns all items via Scan when no conditions', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'alert': { table: 'alerts', columns: { msg: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('alerts'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({
+      Items: [{ id: '1', msg: 'A' }, { id: '2', msg: 'B' }],
+      LastEvaluatedKey: undefined,
+    });
+
+    const records = await db.findAll('alert');
+
+    assert.strictEqual(records.length, 2, 'returns 2 records');
+    assert.ok(deps.buildScan.calledOnce, 'buildScan used');
+    assert.ok(deps.createRecord.calledTwice, 'createRecord called for each item');
+  });
+
+  test('paginates through multiple pages of Scan results', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'alert': { table: 'alerts', columns: {}, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('alerts'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send
+      .onFirstCall().resolves({ Items: [{ id: '1' }], LastEvaluatedKey: { id: '1' } })
+      .onSecondCall().resolves({ Items: [{ id: '2' }], LastEvaluatedKey: undefined });
+
+    const records = await db.findAll('alert');
+
+    assert.strictEqual(records.length, 2, 'both pages combined');
+    assert.strictEqual(mockClient.send.callCount, 2, '2 DynamoDB calls for 2 pages');
+  });
+
+  test('returns empty array for unknown model', async function(assert) {
+    const deps = createMockDeps({ introspectModels: sinon.stub().returns({}) });
+    const { db } = buildDb(deps);
+
+    const records = await db.findAll('nonexistent');
+    assert.deepEqual(records, [], 'empty array returned');
+  });
+
+  test('returns empty array on ResourceNotFoundException', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'alert': { table: 'alerts', columns: {}, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('alerts'),
+    });
+    const { db, mockClient } = buildDb(deps);
+    const err = Object.assign(new Error('No table'), { name: 'ResourceNotFoundException' });
+    mockClient.send.rejects(err);
+
+    const records = await db.findAll('alert');
+    assert.deepEqual(records, [], 'empty array on missing table');
+  });
+
+  test('conditions without GSI match use Scan+FilterExpression and log warning', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'alert': { table: 'alerts', columns: { status: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('alerts'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({ Items: [{ id: '1', status: 'active' }], LastEvaluatedKey: undefined });
+
+    const records = await db.findAll('alert', { status: 'active' });
+
+    assert.ok(deps.log.warn.calledOnce, 'warning logged for unindexed scan');
+    assert.ok(deps.buildScan.calledOnce, 'buildScan called (not buildQuery)');
+    assert.strictEqual(records.length, 1);
+  });
+});
+
+module('[Unit] DynamoDBDB.loadMemoryRecords', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('skips models with memory: false', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'session': { table: 'sessions', columns: {}, foreignKeys: {}, idType: 'string' },
+        'alert': { table: 'alerts', columns: {}, foreignKeys: {}, idType: 'string' },
+      }),
+      getTopologicalOrder: sinon.stub().returns(['session', 'alert']),
+      _importOrm: sinon.stub().resolves({
+        default: {
+          instance: {
+            getRecordClasses(name) {
+              // session=true (memory), alert=false (on-demand)
+              return { modelClass: { memory: name === 'session' } };
+            }
+          }
+        }
+      }),
+      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({ Items: [{ id: 's1' }], LastEvaluatedKey: undefined });
+
+    await db.loadMemoryRecords();
+
+    // buildScan should only be called once (for 'session'), not for 'alert'
+    assert.strictEqual(deps.buildScan.callCount, 1, 'Scan only called for memory:true model');
+    assert.ok(deps.log.db.calledWith(`Skipping memory load for 'alert' (memory: false)`), 'skip logged');
+  });
+
+  test('handles ResourceNotFoundException gracefully (table not yet created)', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'session': { table: 'sessions', columns: {}, foreignKeys: {}, idType: 'string' },
+      }),
+      getTopologicalOrder: sinon.stub().returns(['session']),
+      getPluralName: sinon.stub().returns('sessions'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    const err = Object.assign(new Error('No table'), { name: 'ResourceNotFoundException' });
+    mockClient.send.rejects(err);
+
+    await db.loadMemoryRecords(); // should not throw
+
+    assert.ok(deps.log.db.called, 'skip message logged');
+    assert.ok(deps.createRecord.notCalled, 'createRecord not called');
+  });
+});
+
+module('[Unit] DynamoDBDB._evictIfNotMemory', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('evicts record from store when memory resolver returns false', function(assert) {
+    const modelStore = new Map();
+    modelStore.set('abc', { id: 'abc' });
+
+    const deps = createMockDeps({
+      store: {
+        get: sinon.stub().returns(modelStore),
+        _memoryResolver: name => name !== 'alert',
+      },
+    });
+
+    const { db } = buildDb(deps);
+    db._evictIfNotMemory('alert', { id: 'abc' });
+
+    assert.notOk(modelStore.has('abc'), 'record evicted from store');
+  });
+
+  test('does not evict when memory resolver returns true', function(assert) {
+    const modelStore = new Map();
+    modelStore.set('s1', { id: 's1' });
+
+    const deps = createMockDeps({
+      store: {
+        get: sinon.stub().returns(modelStore),
+        _memoryResolver: () => true,
+      },
+    });
+
+    const { db } = buildDb(deps);
+    db._evictIfNotMemory('session', { id: 's1' });
+
+    assert.ok(modelStore.has('s1'), 'record stays in store');
+  });
+
+  test('does nothing when no memory resolver is set', function(assert) {
+    const modelStore = new Map();
+    modelStore.set(1, { id: 1 });
+
+    const deps = createMockDeps({
+      store: {
+        get: sinon.stub().returns(modelStore),
+        _memoryResolver: null,
+      },
+    });
+
+    const { db } = buildDb(deps);
+    db._evictIfNotMemory('alert', { id: 1 });
+
+    assert.ok(modelStore.has(1), 'record untouched without resolver');
+  });
+});

--- a/test/unit/dynamodb/dynamodb-db-test.ts
+++ b/test/unit/dynamodb/dynamodb-db-test.ts
@@ -1,97 +1,14 @@
-// @ts-nocheck
 import QUnit from 'qunit';
 import sinon from 'sinon';
 import DynamoDBDB from '../../../src/dynamodb/dynamodb-db.js';
+import {
+  createMockDeps,
+  resetInstance,
+  buildDb,
+  makeCommandStub,
+} from '../../helpers/dynamodb-test-helper.js';
 
 const { module, test } = QUnit;
-
-/** Command stub factory — returns a class whose instances can be passed to send(). */
-function makeCommandStub(name) {
-  function Cmd(params) { this.params = params; }
-  Cmd.displayName = name;
-  return Cmd;
-}
-
-/** Build a stub loadDocClientCommands dep that resolves to no-op command stubs. */
-function makeDocClientCommands() {
-  return {
-    PutCommand: makeCommandStub('PutCommand'),
-    GetCommand: makeCommandStub('GetCommand'),
-    UpdateCommand: makeCommandStub('UpdateCommand'),
-    DeleteCommand: makeCommandStub('DeleteCommand'),
-    ScanCommand: makeCommandStub('ScanCommand'),
-    QueryCommand: makeCommandStub('QueryCommand'),
-  };
-}
-
-function createMockDeps(overrides = {}) {
-  const docCommands = makeDocClientCommands();
-
-  return {
-    createDocumentClient: sinon.stub().resolves({ send: sinon.stub().resolves({}) }),
-    destroyDocumentClient: sinon.stub().returns(null),
-    loadDocClientCommands: sinon.stub().resolves(docCommands),
-    loadTableCommands: sinon.stub().resolves({
-      DynamoDBClient: function() { this.send = sinon.stub().resolves({ Table: { TableStatus: 'ACTIVE', GlobalSecondaryIndexes: [] } }); },
-      DescribeTableCommand: makeCommandStub('DescribeTableCommand'),
-      CreateTableCommand: makeCommandStub('CreateTableCommand'),
-      UpdateTableCommand: makeCommandStub('UpdateTableCommand'),
-    }),
-    buildPutItem: sinon.stub().returns({ TableName: 'test', Item: {} }),
-    buildGetItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
-    buildUpdateItem: sinon.stub().returns({ TableName: 'test', Key: {}, UpdateExpression: 'SET #x = :x', ExpressionAttributeNames: {}, ExpressionAttributeValues: {}, ReturnValues: 'NONE' }),
-    buildDeleteItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
-    buildScan: sinon.stub().returns({ TableName: 'test' }),
-    buildQuery: sinon.stub().returns({ TableName: 'test', IndexName: 'idx', KeyConditionExpression: '#id = :id', ExpressionAttributeNames: {}, ExpressionAttributeValues: {} }),
-    introspectModels: sinon.stub().returns({}),
-    getTopologicalOrder: sinon.stub().returns([]),
-    getDynamoKeyType: sinon.stub().returns('S'),
-    createRecord: sinon.stub().callsFake((name, data) => ({
-      id: data.id,
-      __model: { __name: name },
-      __data: { ...data },
-      __relationships: {},
-    })),
-    store: { get: sinon.stub(), _memoryResolver: null },
-    getPluralName: sinon.stub().callsFake(name => `${name}s`),
-    config: {
-      rootPath: '/app',
-      orm: {
-        dynamodb: { region: 'us-east-1' }
-      }
-    },
-    log: {
-      db: sinon.stub(),
-      warn: sinon.stub(),
-    },
-    _importOrm: sinon.stub().resolves({
-      default: {
-        instance: {
-          getRecordClasses(_name) {
-            return { modelClass: { memory: true } };
-          },
-          isView() { return false; }
-        }
-      }
-    }),
-    ...overrides,
-  };
-}
-
-// Reset singleton between tests
-function resetInstance() {
-  DynamoDBDB.instance = undefined;
-}
-
-// Build a DynamoDBDB with a pre-wired mock client
-function buildDb(deps) {
-  const db = new DynamoDBDB(deps);
-  const mockClient = {
-    send: sinon.stub().resolves({ Items: [], LastEvaluatedKey: undefined }),
-  };
-  db.client = mockClient;
-  return { db, mockClient };
-}
 
 module('[Unit] DynamoDBDB — constructor + singleton', function(hooks) {
   hooks.beforeEach(resetInstance);
@@ -105,12 +22,21 @@ module('[Unit] DynamoDBDB — constructor + singleton', function(hooks) {
   });
 
   test('throws when dynamodb config missing', function(assert) {
-    const deps = createMockDeps({ config: { rootPath: '/app', orm: {} } });
+    const deps = createMockDeps({
+      config: { rootPath: '/app', orm: {} } as typeof deps.config,
+    });
     assert.throws(
       () => new DynamoDBDB(deps),
       /DynamoDB configuration/,
       'error thrown when dynamodb not configured'
     );
+  });
+
+  test('uses this.constructor for singleton key (subclass-safe)', function(assert) {
+    const deps = createMockDeps();
+    const db = new DynamoDBDB(deps);
+    // Singleton should be stored on DynamoDBDB, not on a parent class static
+    assert.strictEqual(DynamoDBDB.instance, db, 'instance stored on DynamoDBDB');
   });
 });
 
@@ -163,6 +89,287 @@ module('[Unit] DynamoDBDB.shutdown', function(hooks) {
   });
 });
 
+module('[Unit] DynamoDBDB.persist — create', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('calls PutItem with attribute_not_exists(id) condition', async function(assert) {
+    const recordId = 'r1';
+    const record = { id: recordId, __data: { id: recordId, name: 'Alice' }, __relationships: {} };
+
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+      store: {
+        get: sinon.stub().returns(record),
+        _memoryResolver: null,
+      } as unknown as typeof deps.store,
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({});
+
+    await db.persist('create', 'user', { rawData: {} }, { data: { id: recordId } });
+
+    assert.ok(deps.buildPutItem.calledOnce, 'buildPutItem called');
+    const putArgs = deps.buildPutItem.firstCall.args;
+    assert.strictEqual(putArgs[0], 'users', 'correct table name');
+    assert.strictEqual(putArgs[2], 'attribute_not_exists(id)', 'condition expression set');
+    assert.ok(mockClient.send.calledOnce, 'send called once (PutCommand)');
+  });
+
+  test('generates ULID for numeric-ID model with __pendingSqlId', async function(assert) {
+    const recordId = 99;
+    const record = {
+      id: recordId,
+      __data: { id: recordId, name: 'Bob', __pendingSqlId: true },
+      __relationships: {},
+    };
+
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'number' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+      store: {
+        get: sinon.stub().returns(record),
+        _memoryResolver: null,
+      } as unknown as typeof deps.store,
+    });
+
+    // Store needs .get(modelName) -> Map for the re-key step
+    const modelStoreMap = new Map<unknown, unknown>();
+    modelStoreMap.set(recordId, record);
+    (deps.store as unknown as { get: sinon.SinonStub }).get
+      .withArgs('user', recordId).returns(record)
+      .withArgs('user').returns(modelStoreMap);
+
+    const response = { data: { id: recordId } };
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({});
+
+    await db.persist('create', 'user', { rawData: { __pendingSqlId: true } }, response);
+
+    assert.ok(deps.buildPutItem.calledOnce, 'buildPutItem called');
+    const item = deps.buildPutItem.firstCall.args[1];
+    // ULID is a 26-char Crockford base32 string
+    assert.ok(typeof item.id === 'string' && item.id.length === 26, 'id replaced with ULID string');
+    assert.ok(typeof response.data.id === 'string', 'response.data.id updated to ULID');
+  });
+});
+
+module('[Unit] DynamoDBDB.persist — update', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('calls UpdateItem with SET expression from diff', async function(assert) {
+    const record = {
+      id: 'r1',
+      __data: { id: 'r1', name: 'Alice Updated' },
+      __relationships: {},
+    };
+
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({});
+
+    await db.persist('update', 'user', {
+      record: record as unknown as import('../../../src/types/orm-types.js').OrmRecord,
+      oldState: { name: 'Alice' },
+    }, {});
+
+    assert.ok(deps.buildUpdateItem.calledOnce, 'buildUpdateItem called');
+    const [tableName, key, changedData] = deps.buildUpdateItem.firstCall.args;
+    assert.strictEqual(tableName, 'users', 'correct table');
+    assert.deepEqual(key, { id: 'r1' }, 'correct key');
+    assert.deepEqual(changedData, { name: 'Alice Updated' }, 'diff contains only changed columns');
+    assert.ok(mockClient.send.calledOnce, 'UpdateCommand sent');
+  });
+
+  test('skips UpdateItem when no columns changed', async function(assert) {
+    const record = {
+      id: 'r1',
+      __data: { id: 'r1', name: 'Alice' },
+      __relationships: {},
+    };
+
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+
+    await db.persist('update', 'user', {
+      record: record as unknown as import('../../../src/types/orm-types.js').OrmRecord,
+      oldState: { name: 'Alice' },  // same — no diff
+    }, {});
+
+    assert.ok(mockClient.send.notCalled, 'no DynamoDB call when nothing changed');
+  });
+});
+
+module('[Unit] DynamoDBDB.persist — delete', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('calls DeleteItem with correct key', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: {}, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({});
+
+    await db.persist('delete', 'user', { recordId: 'r1' }, {});
+
+    assert.ok(deps.buildDeleteItem.calledOnce, 'buildDeleteItem called');
+    const [tableName, key] = deps.buildDeleteItem.firstCall.args;
+    assert.strictEqual(tableName, 'users', 'correct table');
+    assert.deepEqual(key, { id: 'r1' }, 'correct key');
+    assert.ok(mockClient.send.calledOnce, 'DeleteCommand sent');
+  });
+
+  test('skips DeleteItem when recordId is null', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: {}, foreignKeys: {}, idType: 'string' }
+      }),
+    });
+    const { db, mockClient } = buildDb(deps);
+
+    await db.persist('delete', 'user', { recordId: null }, {});
+
+    assert.ok(mockClient.send.notCalled, 'no DynamoDB call when recordId is null');
+  });
+});
+
+module('[Unit] DynamoDBDB.startup', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('calls DescribeTable and skips CreateTable when table already ACTIVE', async function(assert) {
+    const rawClientSend = sinon.stub().resolves({
+      Table: { TableStatus: 'ACTIVE', GlobalSecondaryIndexes: [] }
+    });
+
+    const DescribeTableCommand = makeCommandStub('DescribeTableCommand');
+    const CreateTableCommand = makeCommandStub('CreateTableCommand');
+    const UpdateTableCommand = makeCommandStub('UpdateTableCommand');
+
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+      loadTableCommands: sinon.stub().resolves({
+        DynamoDBClient: function(this: { send: sinon.SinonStub }) { this.send = rawClientSend; },
+        DescribeTableCommand,
+        CreateTableCommand,
+        UpdateTableCommand,
+      }),
+    });
+
+    const { db } = buildDb(deps);
+    await db.startup();
+
+    assert.ok(rawClientSend.calledOnce, 'DescribeTable called once');
+    const sentCmd = rawClientSend.firstCall.args[0];
+    assert.ok(sentCmd instanceof DescribeTableCommand, 'DescribeTableCommand sent');
+    assert.ok(!rawClientSend.args.some((a: unknown[]) => a[0] instanceof CreateTableCommand), 'CreateTable NOT called');
+  });
+
+  test('calls CreateTable when DescribeTable throws ResourceNotFoundException', async function(assert) {
+    const DescribeTableCommand = makeCommandStub('DescribeTableCommand');
+    const CreateTableCommand = makeCommandStub('CreateTableCommand');
+    const UpdateTableCommand = makeCommandStub('UpdateTableCommand');
+
+    const rawClientSend = sinon.stub();
+    // Call 0: DescribeTable → ResourceNotFoundException (table missing)
+    // Call 1: CreateTable → resolves
+    // Call 2: _waitForTableActive polls DescribeTable → ACTIVE
+    rawClientSend.onCall(0).rejects(Object.assign(new Error('No such table'), { name: 'ResourceNotFoundException' }));
+    rawClientSend.onCall(1).resolves({});  // CreateTable
+    rawClientSend.onCall(2).resolves({ Table: { TableStatus: 'ACTIVE' } });  // poll
+
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+      loadTableCommands: sinon.stub().resolves({
+        DynamoDBClient: function(this: { send: sinon.SinonStub }) { this.send = rawClientSend; },
+        DescribeTableCommand,
+        CreateTableCommand,
+        UpdateTableCommand,
+      }),
+    });
+
+    const { db } = buildDb(deps);
+    await db.startup();
+
+    // 1st call = DescribeTable (throws), 2nd call = CreateTable, 3rd call = DescribeTable (ACTIVE poll)
+    assert.ok(rawClientSend.callCount >= 2, 'at least 2 calls made');
+    assert.ok(rawClientSend.args[1][0] instanceof CreateTableCommand, 'CreateTableCommand sent on 2nd call');
+  });
+
+  test('calls UpdateTable for missing GSIs on existing table', async function(assert) {
+    const DescribeTableCommand = makeCommandStub('DescribeTableCommand');
+    const CreateTableCommand = makeCommandStub('CreateTableCommand');
+    const UpdateTableCommand = makeCommandStub('UpdateTableCommand');
+
+    const rawClientSend = sinon.stub();
+    // DescribeTable: table exists but no GSIs
+    rawClientSend.onFirstCall().resolves({ Table: { TableStatus: 'ACTIVE', GlobalSecondaryIndexes: [] } });
+    // Poll after UpdateTable
+    rawClientSend.onSecondCall().resolves({ Table: { TableStatus: 'ACTIVE' } });
+    // UpdateTable itself
+    rawClientSend.onThirdCall().resolves({});
+
+    // Reorder stubs: UpdateTable is called at index 1, DescribeTable poll at index 2
+    rawClientSend.reset();
+    rawClientSend.onCall(0).resolves({ Table: { TableStatus: 'ACTIVE', GlobalSecondaryIndexes: [] } });
+    rawClientSend.onCall(1).resolves({});  // UpdateTable
+    rawClientSend.onCall(2).resolves({ Table: { TableStatus: 'ACTIVE' } });  // poll
+
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'comment': {
+          table: 'comments',
+          columns: { body: 'S' },
+          foreignKeys: { post_id: { references: 'posts', column: 'id' } },
+          idType: 'string',
+        }
+      }),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
+      loadTableCommands: sinon.stub().resolves({
+        DynamoDBClient: function(this: { send: sinon.SinonStub }) { this.send = rawClientSend; },
+        DescribeTableCommand,
+        CreateTableCommand,
+        UpdateTableCommand,
+      }),
+    });
+
+    const { db } = buildDb(deps);
+    await db.startup();
+
+    assert.ok(rawClientSend.args.some((a: unknown[]) => a[0] instanceof UpdateTableCommand), 'UpdateTableCommand sent for missing GSI');
+  });
+});
+
 module('[Unit] DynamoDBDB.findRecord', function(hooks) {
   hooks.beforeEach(resetInstance);
   hooks.afterEach(() => { resetInstance(); sinon.restore(); });
@@ -182,7 +389,7 @@ module('[Unit] DynamoDBDB.findRecord', function(hooks) {
 
     assert.ok(deps.buildGetItem.calledOnce, 'buildGetItem called');
     assert.ok(deps.createRecord.calledOnce, 'createRecord called');
-    assert.strictEqual(record.id, 'abc', 'record has correct id');
+    assert.strictEqual(record!.id, 'abc', 'record has correct id');
   });
 
   test('returns undefined when no item found', async function(assert) {
@@ -246,8 +453,8 @@ module('[Unit] DynamoDBDB.findRecord', function(hooks) {
     await db.findRecord('comment', 'c1');
 
     const passedData = deps.createRecord.firstCall.args[1];
-    assert.strictEqual(passedData.post, 'p1', 'FK column remapped to relationship key');
-    assert.strictEqual(passedData.post_id, undefined, 'original FK column removed');
+    assert.strictEqual(passedData['post'], 'p1', 'FK column remapped to relationship key');
+    assert.strictEqual(passedData['post_id'], undefined, 'original FK column removed');
   });
 });
 
@@ -331,7 +538,7 @@ module('[Unit] DynamoDBDB.findAll', function(hooks) {
 
     const records = await db.findAll('alert', { status: 'active' });
 
-    assert.ok(deps.log.warn.calledOnce, 'warning logged for unindexed scan');
+    assert.ok((deps.log as unknown as { warn: sinon.SinonStub }).warn.calledOnce, 'warning logged for unindexed scan');
     assert.ok(deps.buildScan.calledOnce, 'buildScan called (not buildQuery)');
     assert.strictEqual(records.length, 1);
   });
@@ -351,14 +558,13 @@ module('[Unit] DynamoDBDB.loadMemoryRecords', function(hooks) {
       _importOrm: sinon.stub().resolves({
         default: {
           instance: {
-            getRecordClasses(name) {
-              // session=true (memory), alert=false (on-demand)
+            getRecordClasses(name: string) {
               return { modelClass: { memory: name === 'session' } };
             }
           }
         }
       }),
-      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
     });
 
     const { db, mockClient } = buildDb(deps);
@@ -366,9 +572,11 @@ module('[Unit] DynamoDBDB.loadMemoryRecords', function(hooks) {
 
     await db.loadMemoryRecords();
 
-    // buildScan should only be called once (for 'session'), not for 'alert'
     assert.strictEqual(deps.buildScan.callCount, 1, 'Scan only called for memory:true model');
-    assert.ok(deps.log.db.calledWith(`Skipping memory load for 'alert' (memory: false)`), 'skip logged');
+    assert.ok(
+      (deps.log as unknown as { db: sinon.SinonStub }).db.calledWith(`Skipping memory load for 'alert' (memory: false)`),
+      'skip logged'
+    );
   });
 
   test('handles ResourceNotFoundException gracefully (table not yet created)', async function(assert) {
@@ -386,7 +594,7 @@ module('[Unit] DynamoDBDB.loadMemoryRecords', function(hooks) {
 
     await db.loadMemoryRecords(); // should not throw
 
-    assert.ok(deps.log.db.called, 'skip message logged');
+    assert.ok((deps.log as unknown as { db: sinon.SinonStub }).db.called, 'skip message logged');
     assert.ok(deps.createRecord.notCalled, 'createRecord not called');
   });
 });
@@ -402,11 +610,12 @@ module('[Unit] DynamoDBDB._evictIfNotMemory', function(hooks) {
     const deps = createMockDeps({
       store: {
         get: sinon.stub().returns(modelStore),
-        _memoryResolver: name => name !== 'alert',
-      },
+        _memoryResolver: (name: string) => name !== 'alert',
+      } as unknown as typeof deps.store,
     });
 
     const { db } = buildDb(deps);
+    // @ts-expect-error — accessing private method for test coverage
     db._evictIfNotMemory('alert', { id: 'abc' });
 
     assert.notOk(modelStore.has('abc'), 'record evicted from store');
@@ -420,10 +629,11 @@ module('[Unit] DynamoDBDB._evictIfNotMemory', function(hooks) {
       store: {
         get: sinon.stub().returns(modelStore),
         _memoryResolver: () => true,
-      },
+      } as unknown as typeof deps.store,
     });
 
     const { db } = buildDb(deps);
+    // @ts-expect-error — accessing private method for test coverage
     db._evictIfNotMemory('session', { id: 's1' });
 
     assert.ok(modelStore.has('s1'), 'record stays in store');
@@ -437,10 +647,11 @@ module('[Unit] DynamoDBDB._evictIfNotMemory', function(hooks) {
       store: {
         get: sinon.stub().returns(modelStore),
         _memoryResolver: null,
-      },
+      } as unknown as typeof deps.store,
     });
 
     const { db } = buildDb(deps);
+    // @ts-expect-error — accessing private method for test coverage
     db._evictIfNotMemory('alert', { id: 1 });
 
     assert.ok(modelStore.has(1), 'record untouched without resolver');

--- a/test/unit/dynamodb/gsi-routing-test.ts
+++ b/test/unit/dynamodb/gsi-routing-test.ts
@@ -1,77 +1,13 @@
-// @ts-nocheck
 import QUnit from 'qunit';
 import sinon from 'sinon';
 import DynamoDBDB from '../../../src/dynamodb/dynamodb-db.js';
+import {
+  createMockDeps,
+  resetInstance,
+  buildDb,
+} from '../../helpers/dynamodb-test-helper.js';
 
 const { module, test } = QUnit;
-
-function makeCommandStub(name) {
-  function Cmd(params) { this.params = params; }
-  Cmd.displayName = name;
-  return Cmd;
-}
-
-function makeDocClientCommands() {
-  return {
-    PutCommand: makeCommandStub('PutCommand'),
-    GetCommand: makeCommandStub('GetCommand'),
-    UpdateCommand: makeCommandStub('UpdateCommand'),
-    DeleteCommand: makeCommandStub('DeleteCommand'),
-    ScanCommand: makeCommandStub('ScanCommand'),
-    QueryCommand: makeCommandStub('QueryCommand'),
-  };
-}
-
-function createMockDeps(overrides = {}) {
-  return {
-    createDocumentClient: sinon.stub().resolves({ send: sinon.stub().resolves({}) }),
-    destroyDocumentClient: sinon.stub().returns(null),
-    loadDocClientCommands: sinon.stub().resolves(makeDocClientCommands()),
-    loadTableCommands: sinon.stub().resolves({}),
-    buildPutItem: sinon.stub().returns({ TableName: 'test', Item: {} }),
-    buildGetItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
-    buildUpdateItem: sinon.stub().returns({ TableName: 'test', Key: {}, UpdateExpression: 'SET', ExpressionAttributeNames: {}, ExpressionAttributeValues: {}, ReturnValues: 'NONE' }),
-    buildDeleteItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
-    buildScan: sinon.stub().returns({ TableName: 'test' }),
-    buildQuery: sinon.stub().returns({ TableName: 'test', IndexName: 'idx', KeyConditionExpression: '', ExpressionAttributeNames: {}, ExpressionAttributeValues: {} }),
-    introspectModels: sinon.stub().returns({}),
-    getTopologicalOrder: sinon.stub().returns([]),
-    getDynamoKeyType: sinon.stub().returns('S'),
-    createRecord: sinon.stub().callsFake((name, data) => ({
-      id: data.id,
-      __model: { __name: name },
-      __data: { ...data },
-      __relationships: {},
-    })),
-    store: { get: sinon.stub(), _memoryResolver: null },
-    getPluralName: sinon.stub().callsFake(name => `${name}s`),
-    config: {
-      rootPath: '/app',
-      orm: { dynamodb: { region: 'us-east-1' } }
-    },
-    log: { db: sinon.stub(), warn: sinon.stub() },
-    _importOrm: sinon.stub().resolves({
-      default: {
-        instance: {
-          getRecordClasses(_name) { return { modelClass: { memory: true } }; },
-          isView() { return false; }
-        }
-      }
-    }),
-    ...overrides,
-  };
-}
-
-function resetInstance() {
-  DynamoDBDB.instance = undefined;
-}
-
-function buildDb(deps) {
-  const db = new DynamoDBDB(deps);
-  const mockClient = { send: sinon.stub().resolves({ Items: [], LastEvaluatedKey: undefined }) };
-  db.client = mockClient;
-  return { db, mockClient };
-}
 
 module('[Unit] DynamoDBDB GSI Registry — _buildGsiRegistry', function(hooks) {
   hooks.beforeEach(resetInstance);
@@ -86,12 +22,14 @@ module('[Unit] DynamoDBDB GSI Registry — _buildGsiRegistry', function(hooks) {
     });
 
     const { db } = buildDb(deps);
-    db['_buildGsiRegistry']();  // re-invoke explicitly after init bypassed
+    // @ts-expect-error — accessing private method for test coverage
+    db._buildGsiRegistry();  // re-invoke explicitly after init bypassed
 
     // Access private registry via bracket notation
-    const registry = db['_gsiRegistry'];
+    // @ts-expect-error — accessing private field for test coverage
+    const registry: Map<string, Map<string, string>> = db._gsiRegistry;
     assert.ok(registry.has('user'), 'user is in registry');
-    assert.strictEqual(registry.get('user').size, 0, 'no GSIs for user (no FKs)');
+    assert.strictEqual(registry.get('user')!.size, 0, 'no GSIs for user (no FKs)');
   });
 
   test('FK column creates a GSI entry', function(assert) {
@@ -104,14 +42,16 @@ module('[Unit] DynamoDBDB GSI Registry — _buildGsiRegistry', function(hooks) {
           idType: 'string',
         }
       }),
-      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
     });
 
     const { db } = buildDb(deps);
-    db['_buildGsiRegistry']();
+    // @ts-expect-error — accessing private method for test coverage
+    db._buildGsiRegistry();
 
-    const registry = db['_gsiRegistry'];
-    const commentGsis = registry.get('comment');
+    // @ts-expect-error — accessing private field for test coverage
+    const registry: Map<string, Map<string, string>> = db._gsiRegistry;
+    const commentGsis = registry.get('comment')!;
     assert.ok(commentGsis.has('post_id'), 'post_id gets a GSI entry');
     assert.strictEqual(commentGsis.get('post_id'), 'comments-post_id-index', 'GSI named correctly');
   });
@@ -129,14 +69,16 @@ module('[Unit] DynamoDBDB GSI Registry — _buildGsiRegistry', function(hooks) {
           idType: 'string',
         }
       }),
-      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
     });
 
     const { db } = buildDb(deps);
-    db['_buildGsiRegistry']();
+    // @ts-expect-error — accessing private method for test coverage
+    db._buildGsiRegistry();
 
-    const registry = db['_gsiRegistry'];
-    const orderGsis = registry.get('order');
+    // @ts-expect-error — accessing private field for test coverage
+    const registry: Map<string, Map<string, string>> = db._gsiRegistry;
+    const orderGsis = registry.get('order')!;
     assert.strictEqual(orderGsis.size, 2, '2 GSIs for 2 FK columns');
     assert.ok(orderGsis.has('user_id'), 'user_id GSI present');
     assert.ok(orderGsis.has('product_id'), 'product_id GSI present');
@@ -157,19 +99,20 @@ module('[Unit] DynamoDBDB GSI Routing — findAll with conditions', function(hoo
           idType: 'string',
         }
       }),
-      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
     });
 
     const { db, mockClient } = buildDb(deps);
     // Rebuild GSI registry with FK knowledge
-    db['_buildGsiRegistry']();
+    // @ts-expect-error — accessing private method for test coverage
+    db._buildGsiRegistry();
     mockClient.send.resolves({ Items: [{ id: 'c1', body: 'Hello', post_id: 'p1' }], LastEvaluatedKey: undefined });
 
     const records = await db.findAll('comment', { post_id: 'p1' });
 
     assert.ok(deps.buildQuery.calledOnce, 'buildQuery used (GSI route)');
     assert.ok(deps.buildScan.notCalled, 'buildScan NOT used');
-    assert.ok(deps.log.warn.notCalled, 'no warning logged for indexed query');
+    assert.ok((deps.log as unknown as { warn: sinon.SinonStub }).warn.notCalled, 'no warning logged for indexed query');
     assert.strictEqual(records.length, 1, 'one record returned');
   });
 
@@ -183,19 +126,23 @@ module('[Unit] DynamoDBDB GSI Routing — findAll with conditions', function(hoo
           idType: 'string',
         }
       }),
-      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
     });
 
     const { db, mockClient } = buildDb(deps);
-    db['_buildGsiRegistry']();
+    // @ts-expect-error — accessing private method for test coverage
+    db._buildGsiRegistry();
     mockClient.send.resolves({ Items: [], LastEvaluatedKey: undefined });
 
     await db.findAll('comment', { status: 'active' });
 
     assert.ok(deps.buildScan.calledOnce, 'buildScan used for non-indexed condition');
     assert.ok(deps.buildQuery.notCalled, 'buildQuery NOT used');
-    assert.ok(deps.log.warn.calledOnce, 'warning logged for unindexed scan');
-    assert.ok(deps.log.warn.firstCall.args[0].includes('no GSI for conditions'), 'warning mentions GSI');
+    assert.ok((deps.log as unknown as { warn: sinon.SinonStub }).warn.calledOnce, 'warning logged for unindexed scan');
+    assert.ok(
+      (deps.log as unknown as { warn: sinon.SinonStub }).warn.firstCall.args[0].includes('no GSI for conditions'),
+      'warning mentions GSI'
+    );
   });
 
   test('GSI query result is further filtered by remaining conditions', async function(assert) {
@@ -208,11 +155,12 @@ module('[Unit] DynamoDBDB GSI Routing — findAll with conditions', function(hoo
           idType: 'string',
         }
       }),
-      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
     });
 
     const { db, mockClient } = buildDb(deps);
-    db['_buildGsiRegistry']();
+    // @ts-expect-error — accessing private method for test coverage
+    db._buildGsiRegistry();
 
     // Two items from GSI; one passes the remaining filter, one doesn't
     mockClient.send.resolves({
@@ -227,7 +175,7 @@ module('[Unit] DynamoDBDB GSI Routing — findAll with conditions', function(hoo
 
     assert.ok(deps.buildQuery.calledOnce, 'Query used for GSI key');
     assert.strictEqual(records.length, 1, 'only 1 record matches remaining conditions');
-    assert.strictEqual(records[0].id, 'c1', 'correct record returned');
+    assert.strictEqual(records[0]!.id, 'c1', 'correct record returned');
   });
 });
 
@@ -242,14 +190,15 @@ module('[Unit] DynamoDBDB GSI provisioning — _buildGsiDefinitions', function(h
     const { db } = buildDb(deps);
 
     const schema = { table: 'users', columns: {}, foreignKeys: {}, idType: 'string', relationships: { belongsTo: {}, hasMany: {} }, memory: true };
-    const gsis = db['_buildGsiDefinitions']('user', schema);
+    // @ts-expect-error — accessing private method for test coverage
+    const gsis: unknown[] = db._buildGsiDefinitions('user', schema);
 
     assert.deepEqual(gsis, [], 'no GSIs for model without FKs');
   });
 
   test('returns one GSI definition per FK column', function(assert) {
     const deps = createMockDeps({
-      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
     });
     const { db } = buildDb(deps);
 
@@ -265,7 +214,8 @@ module('[Unit] DynamoDBDB GSI provisioning — _buildGsiDefinitions', function(h
       memory: true,
     };
 
-    const gsis = db['_buildGsiDefinitions']('comment', schema);
+    // @ts-expect-error — accessing private method for test coverage
+    const gsis = db._buildGsiDefinitions('comment', schema) as Array<{ IndexName: string; Projection: { ProjectionType: string }; KeySchema: Array<{ KeyType: string }> }>;
 
     assert.strictEqual(gsis.length, 2, '2 GSI definitions');
 
@@ -276,13 +226,13 @@ module('[Unit] DynamoDBDB GSI provisioning — _buildGsiDefinitions', function(h
     // Each GSI should be ALL projection
     for (const gsi of gsis) {
       assert.strictEqual(gsi.Projection.ProjectionType, 'ALL', 'ALL projection');
-      assert.strictEqual(gsi.KeySchema[0].KeyType, 'HASH', 'HASH key type');
+      assert.strictEqual(gsi.KeySchema[0]!.KeyType, 'HASH', 'HASH key type');
     }
   });
 
   test('_buildAttributeDefinitions includes id and FK columns', function(assert) {
     const deps = createMockDeps({
-      getDynamoKeyType: sinon.stub().callsFake(type => type === 'string' ? 'S' : 'N'),
+      getDynamoKeyType: sinon.stub().callsFake((type: string) => type === 'string' ? 'S' : 'N'),
     });
     const { db } = buildDb(deps);
 
@@ -295,15 +245,16 @@ module('[Unit] DynamoDBDB GSI provisioning — _buildGsiDefinitions', function(h
       memory: true,
     };
 
-    const attrDefs = db['_buildAttributeDefinitions'](schema);
+    // @ts-expect-error — accessing private method for test coverage
+    const attrDefs = db._buildAttributeDefinitions(schema) as Array<{ AttributeName: string; AttributeType: string }>;
 
     assert.strictEqual(attrDefs.length, 2, 'id + post_id');
     const idDef = attrDefs.find(d => d.AttributeName === 'id');
     const fkDef = attrDefs.find(d => d.AttributeName === 'post_id');
     assert.ok(idDef, 'id attribute definition present');
     assert.ok(fkDef, 'post_id attribute definition present');
-    assert.strictEqual(idDef.AttributeType, 'S', 'id is S for string idType');
-    assert.strictEqual(fkDef.AttributeType, 'S', 'FK is S by default');
+    assert.strictEqual(idDef!.AttributeType, 'S', 'id is S for string idType');
+    assert.strictEqual(fkDef!.AttributeType, 'S', 'FK is S by default');
   });
 
   test('_buildAttributeDefinitions deduplicates repeated attributes', function(assert) {
@@ -322,7 +273,8 @@ module('[Unit] DynamoDBDB GSI provisioning — _buildGsiDefinitions', function(h
       memory: true,
     };
 
-    const attrDefs = db['_buildAttributeDefinitions'](schema);
+    // @ts-expect-error — accessing private method for test coverage
+    const attrDefs = db._buildAttributeDefinitions(schema) as Array<{ AttributeName: string }>;
 
     const idCount = attrDefs.filter(d => d.AttributeName === 'id').length;
     assert.strictEqual(idCount, 1, 'id not duplicated');

--- a/test/unit/dynamodb/gsi-routing-test.ts
+++ b/test/unit/dynamodb/gsi-routing-test.ts
@@ -1,0 +1,330 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import DynamoDBDB from '../../../src/dynamodb/dynamodb-db.js';
+
+const { module, test } = QUnit;
+
+function makeCommandStub(name) {
+  function Cmd(params) { this.params = params; }
+  Cmd.displayName = name;
+  return Cmd;
+}
+
+function makeDocClientCommands() {
+  return {
+    PutCommand: makeCommandStub('PutCommand'),
+    GetCommand: makeCommandStub('GetCommand'),
+    UpdateCommand: makeCommandStub('UpdateCommand'),
+    DeleteCommand: makeCommandStub('DeleteCommand'),
+    ScanCommand: makeCommandStub('ScanCommand'),
+    QueryCommand: makeCommandStub('QueryCommand'),
+  };
+}
+
+function createMockDeps(overrides = {}) {
+  return {
+    createDocumentClient: sinon.stub().resolves({ send: sinon.stub().resolves({}) }),
+    destroyDocumentClient: sinon.stub().returns(null),
+    loadDocClientCommands: sinon.stub().resolves(makeDocClientCommands()),
+    loadTableCommands: sinon.stub().resolves({}),
+    buildPutItem: sinon.stub().returns({ TableName: 'test', Item: {} }),
+    buildGetItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
+    buildUpdateItem: sinon.stub().returns({ TableName: 'test', Key: {}, UpdateExpression: 'SET', ExpressionAttributeNames: {}, ExpressionAttributeValues: {}, ReturnValues: 'NONE' }),
+    buildDeleteItem: sinon.stub().returns({ TableName: 'test', Key: {} }),
+    buildScan: sinon.stub().returns({ TableName: 'test' }),
+    buildQuery: sinon.stub().returns({ TableName: 'test', IndexName: 'idx', KeyConditionExpression: '', ExpressionAttributeNames: {}, ExpressionAttributeValues: {} }),
+    introspectModels: sinon.stub().returns({}),
+    getTopologicalOrder: sinon.stub().returns([]),
+    getDynamoKeyType: sinon.stub().returns('S'),
+    createRecord: sinon.stub().callsFake((name, data) => ({
+      id: data.id,
+      __model: { __name: name },
+      __data: { ...data },
+      __relationships: {},
+    })),
+    store: { get: sinon.stub(), _memoryResolver: null },
+    getPluralName: sinon.stub().callsFake(name => `${name}s`),
+    config: {
+      rootPath: '/app',
+      orm: { dynamodb: { region: 'us-east-1' } }
+    },
+    log: { db: sinon.stub(), warn: sinon.stub() },
+    _importOrm: sinon.stub().resolves({
+      default: {
+        instance: {
+          getRecordClasses(_name) { return { modelClass: { memory: true } }; },
+          isView() { return false; }
+        }
+      }
+    }),
+    ...overrides,
+  };
+}
+
+function resetInstance() {
+  DynamoDBDB.instance = undefined;
+}
+
+function buildDb(deps) {
+  const db = new DynamoDBDB(deps);
+  const mockClient = { send: sinon.stub().resolves({ Items: [], LastEvaluatedKey: undefined }) };
+  db.client = mockClient;
+  return { db, mockClient };
+}
+
+module('[Unit] DynamoDBDB GSI Registry — _buildGsiRegistry', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('no GSIs for models with no FK columns', function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db } = buildDb(deps);
+    db['_buildGsiRegistry']();  // re-invoke explicitly after init bypassed
+
+    // Access private registry via bracket notation
+    const registry = db['_gsiRegistry'];
+    assert.ok(registry.has('user'), 'user is in registry');
+    assert.strictEqual(registry.get('user').size, 0, 'no GSIs for user (no FKs)');
+  });
+
+  test('FK column creates a GSI entry', function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'comment': {
+          table: 'comments',
+          columns: { body: 'S' },
+          foreignKeys: { post_id: { references: 'posts', column: 'id' } },
+          idType: 'string',
+        }
+      }),
+      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+    });
+
+    const { db } = buildDb(deps);
+    db['_buildGsiRegistry']();
+
+    const registry = db['_gsiRegistry'];
+    const commentGsis = registry.get('comment');
+    assert.ok(commentGsis.has('post_id'), 'post_id gets a GSI entry');
+    assert.strictEqual(commentGsis.get('post_id'), 'comments-post_id-index', 'GSI named correctly');
+  });
+
+  test('multiple FK columns produce multiple GSI entries', function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'order': {
+          table: 'orders',
+          columns: { amount: 'N' },
+          foreignKeys: {
+            user_id: { references: 'users', column: 'id' },
+            product_id: { references: 'products', column: 'id' },
+          },
+          idType: 'string',
+        }
+      }),
+      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+    });
+
+    const { db } = buildDb(deps);
+    db['_buildGsiRegistry']();
+
+    const registry = db['_gsiRegistry'];
+    const orderGsis = registry.get('order');
+    assert.strictEqual(orderGsis.size, 2, '2 GSIs for 2 FK columns');
+    assert.ok(orderGsis.has('user_id'), 'user_id GSI present');
+    assert.ok(orderGsis.has('product_id'), 'product_id GSI present');
+  });
+});
+
+module('[Unit] DynamoDBDB GSI Routing — findAll with conditions', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('routes to Query when condition matches GSI key (FK column)', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'comment': {
+          table: 'comments',
+          columns: { body: 'S' },
+          foreignKeys: { post_id: { references: 'posts', column: 'id' } },
+          idType: 'string',
+        }
+      }),
+      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    // Rebuild GSI registry with FK knowledge
+    db['_buildGsiRegistry']();
+    mockClient.send.resolves({ Items: [{ id: 'c1', body: 'Hello', post_id: 'p1' }], LastEvaluatedKey: undefined });
+
+    const records = await db.findAll('comment', { post_id: 'p1' });
+
+    assert.ok(deps.buildQuery.calledOnce, 'buildQuery used (GSI route)');
+    assert.ok(deps.buildScan.notCalled, 'buildScan NOT used');
+    assert.ok(deps.log.warn.notCalled, 'no warning logged for indexed query');
+    assert.strictEqual(records.length, 1, 'one record returned');
+  });
+
+  test('falls back to Scan+FilterExpression for non-indexed condition', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'comment': {
+          table: 'comments',
+          columns: { body: 'S', status: 'S' },
+          foreignKeys: {},
+          idType: 'string',
+        }
+      }),
+      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    db['_buildGsiRegistry']();
+    mockClient.send.resolves({ Items: [], LastEvaluatedKey: undefined });
+
+    await db.findAll('comment', { status: 'active' });
+
+    assert.ok(deps.buildScan.calledOnce, 'buildScan used for non-indexed condition');
+    assert.ok(deps.buildQuery.notCalled, 'buildQuery NOT used');
+    assert.ok(deps.log.warn.calledOnce, 'warning logged for unindexed scan');
+    assert.ok(deps.log.warn.firstCall.args[0].includes('no GSI for conditions'), 'warning mentions GSI');
+  });
+
+  test('GSI query result is further filtered by remaining conditions', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'comment': {
+          table: 'comments',
+          columns: { body: 'S', status: 'S' },
+          foreignKeys: { post_id: { references: 'posts', column: 'id' } },
+          idType: 'string',
+        }
+      }),
+      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    db['_buildGsiRegistry']();
+
+    // Two items from GSI; one passes the remaining filter, one doesn't
+    mockClient.send.resolves({
+      Items: [
+        { id: 'c1', body: 'Hello', post_id: 'p1', status: 'active' },
+        { id: 'c2', body: 'World', post_id: 'p1', status: 'deleted' },
+      ],
+      LastEvaluatedKey: undefined,
+    });
+
+    const records = await db.findAll('comment', { post_id: 'p1', status: 'active' });
+
+    assert.ok(deps.buildQuery.calledOnce, 'Query used for GSI key');
+    assert.strictEqual(records.length, 1, 'only 1 record matches remaining conditions');
+    assert.strictEqual(records[0].id, 'c1', 'correct record returned');
+  });
+});
+
+module('[Unit] DynamoDBDB GSI provisioning — _buildGsiDefinitions', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('returns empty array for model with no FKs', function(assert) {
+    const deps = createMockDeps({
+      getPluralName: sinon.stub().returns('users'),
+    });
+    const { db } = buildDb(deps);
+
+    const schema = { table: 'users', columns: {}, foreignKeys: {}, idType: 'string', relationships: { belongsTo: {}, hasMany: {} }, memory: true };
+    const gsis = db['_buildGsiDefinitions']('user', schema);
+
+    assert.deepEqual(gsis, [], 'no GSIs for model without FKs');
+  });
+
+  test('returns one GSI definition per FK column', function(assert) {
+    const deps = createMockDeps({
+      getPluralName: sinon.stub().callsFake(name => `${name}s`),
+    });
+    const { db } = buildDb(deps);
+
+    const schema = {
+      table: 'comments',
+      columns: {},
+      foreignKeys: {
+        post_id: { references: 'posts', column: 'id' },
+        user_id: { references: 'users', column: 'id' },
+      },
+      idType: 'string',
+      relationships: { belongsTo: {}, hasMany: {} },
+      memory: true,
+    };
+
+    const gsis = db['_buildGsiDefinitions']('comment', schema);
+
+    assert.strictEqual(gsis.length, 2, '2 GSI definitions');
+
+    const names = gsis.map(g => g.IndexName);
+    assert.ok(names.includes('comments-post_id-index'), 'post_id GSI named correctly');
+    assert.ok(names.includes('comments-user_id-index'), 'user_id GSI named correctly');
+
+    // Each GSI should be ALL projection
+    for (const gsi of gsis) {
+      assert.strictEqual(gsi.Projection.ProjectionType, 'ALL', 'ALL projection');
+      assert.strictEqual(gsi.KeySchema[0].KeyType, 'HASH', 'HASH key type');
+    }
+  });
+
+  test('_buildAttributeDefinitions includes id and FK columns', function(assert) {
+    const deps = createMockDeps({
+      getDynamoKeyType: sinon.stub().callsFake(type => type === 'string' ? 'S' : 'N'),
+    });
+    const { db } = buildDb(deps);
+
+    const schema = {
+      table: 'comments',
+      columns: {},
+      foreignKeys: { post_id: { references: 'posts', column: 'id' } },
+      idType: 'string',
+      relationships: { belongsTo: {}, hasMany: {} },
+      memory: true,
+    };
+
+    const attrDefs = db['_buildAttributeDefinitions'](schema);
+
+    assert.strictEqual(attrDefs.length, 2, 'id + post_id');
+    const idDef = attrDefs.find(d => d.AttributeName === 'id');
+    const fkDef = attrDefs.find(d => d.AttributeName === 'post_id');
+    assert.ok(idDef, 'id attribute definition present');
+    assert.ok(fkDef, 'post_id attribute definition present');
+    assert.strictEqual(idDef.AttributeType, 'S', 'id is S for string idType');
+    assert.strictEqual(fkDef.AttributeType, 'S', 'FK is S by default');
+  });
+
+  test('_buildAttributeDefinitions deduplicates repeated attributes', function(assert) {
+    const deps = createMockDeps({
+      getDynamoKeyType: sinon.stub().returns('S'),
+    });
+    const { db } = buildDb(deps);
+
+    // Simulate model where id also appears as FK (edge case)
+    const schema = {
+      table: 'weird',
+      columns: {},
+      foreignKeys: { id: { references: 'other', column: 'id' } },  // same as PK
+      idType: 'string',
+      relationships: { belongsTo: {}, hasMany: {} },
+      memory: true,
+    };
+
+    const attrDefs = db['_buildAttributeDefinitions'](schema);
+
+    const idCount = attrDefs.filter(d => d.AttributeName === 'id').length;
+    assert.strictEqual(idCount, 1, 'id not duplicated');
+  });
+});

--- a/test/unit/dynamodb/operation-builder-test.ts
+++ b/test/unit/dynamodb/operation-builder-test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import QUnit from 'qunit';
 import {
   buildPutItem,

--- a/test/unit/dynamodb/operation-builder-test.ts
+++ b/test/unit/dynamodb/operation-builder-test.ts
@@ -1,0 +1,143 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import {
+  buildPutItem,
+  buildGetItem,
+  buildUpdateItem,
+  buildDeleteItem,
+  buildScan,
+  buildQuery,
+} from '../../../src/dynamodb/operation-builder.js';
+
+const { module, test } = QUnit;
+
+module('[Unit] DynamoDB operation-builder — buildPutItem', function() {
+  test('basic put with no condition', function(assert) {
+    const params = buildPutItem('users', { id: '1', name: 'Alice' });
+
+    assert.strictEqual(params.TableName, 'users');
+    assert.deepEqual(params.Item, { id: '1', name: 'Alice' });
+    assert.strictEqual(params.ConditionExpression, undefined, 'no condition when not provided');
+  });
+
+  test('put with condition expression', function(assert) {
+    const params = buildPutItem('users', { id: '1', name: 'Alice' }, 'attribute_not_exists(id)');
+
+    assert.strictEqual(params.ConditionExpression, 'attribute_not_exists(id)');
+  });
+});
+
+module('[Unit] DynamoDB operation-builder — buildGetItem', function() {
+  test('returns correct params for string key', function(assert) {
+    const params = buildGetItem('sessions', { id: 'abc-123' });
+
+    assert.strictEqual(params.TableName, 'sessions');
+    assert.deepEqual(params.Key, { id: 'abc-123' });
+  });
+
+  test('returns correct params for numeric key', function(assert) {
+    const params = buildGetItem('orders', { id: 42 });
+
+    assert.deepEqual(params.Key, { id: 42 });
+  });
+});
+
+module('[Unit] DynamoDB operation-builder — buildUpdateItem', function() {
+  test('builds SET expression for single attribute', function(assert) {
+    const params = buildUpdateItem('users', { id: '1' }, { name: 'Bob' });
+
+    assert.strictEqual(params.TableName, 'users');
+    assert.deepEqual(params.Key, { id: '1' });
+    assert.strictEqual(params.UpdateExpression, 'SET #name = :name');
+    assert.deepEqual(params.ExpressionAttributeNames, { '#name': 'name' });
+    assert.deepEqual(params.ExpressionAttributeValues, { ':name': 'Bob' });
+    assert.strictEqual(params.ReturnValues, 'NONE');
+  });
+
+  test('builds SET expression for multiple attributes', function(assert) {
+    const params = buildUpdateItem('users', { id: '1' }, { name: 'Bob', age: 30 });
+
+    // Both attributes must appear in the expression
+    assert.ok(params.UpdateExpression.includes('#name = :name'), 'name attr present');
+    assert.ok(params.UpdateExpression.includes('#age = :age'), 'age attr present');
+    assert.ok(params.UpdateExpression.startsWith('SET '), 'starts with SET');
+    assert.strictEqual(Object.keys(params.ExpressionAttributeNames).length, 2, '2 name aliases');
+    assert.strictEqual(Object.keys(params.ExpressionAttributeValues).length, 2, '2 value aliases');
+  });
+
+  test('preserves null values in updates', function(assert) {
+    const params = buildUpdateItem('users', { id: '1' }, { deletedAt: null });
+
+    assert.strictEqual(params.ExpressionAttributeValues[':deletedAt'], null, 'null value preserved');
+  });
+});
+
+module('[Unit] DynamoDB operation-builder — buildDeleteItem', function() {
+  test('returns correct params', function(assert) {
+    const params = buildDeleteItem('sessions', { id: 'abc' });
+
+    assert.strictEqual(params.TableName, 'sessions');
+    assert.deepEqual(params.Key, { id: 'abc' });
+  });
+});
+
+module('[Unit] DynamoDB operation-builder — buildScan', function() {
+  test('scan with no conditions', function(assert) {
+    const params = buildScan('alerts');
+
+    assert.strictEqual(params.TableName, 'alerts');
+    assert.strictEqual(params.FilterExpression, undefined, 'no filter');
+    assert.strictEqual(params.ExclusiveStartKey, undefined, 'no start key');
+  });
+
+  test('scan with conditions produces FilterExpression', function(assert) {
+    const params = buildScan('alerts', { status: 'active' });
+
+    assert.ok(params.FilterExpression, 'FilterExpression set');
+    assert.ok(params.FilterExpression.includes('#status = :status'));
+    assert.deepEqual(params.ExpressionAttributeNames, { '#status': 'status' });
+    assert.deepEqual(params.ExpressionAttributeValues, { ':status': 'active' });
+  });
+
+  test('scan with multiple conditions joins them with AND', function(assert) {
+    const params = buildScan('alerts', { status: 'active', type: 'goal' });
+
+    assert.ok(params.FilterExpression.includes(' AND '), 'conditions joined with AND');
+    assert.strictEqual(Object.keys(params.ExpressionAttributeNames).length, 2);
+  });
+
+  test('scan with exclusiveStartKey for pagination', function(assert) {
+    const startKey = { id: 'last-seen-id' };
+    const params = buildScan('alerts', undefined, startKey);
+
+    assert.deepEqual(params.ExclusiveStartKey, startKey);
+    assert.strictEqual(params.FilterExpression, undefined, 'no filter expression');
+  });
+});
+
+module('[Unit] DynamoDB operation-builder — buildQuery', function() {
+  test('builds query for single GSI key condition', function(assert) {
+    const params = buildQuery('sessions', 'user-index', { userId: 'u1' });
+
+    assert.strictEqual(params.TableName, 'sessions');
+    assert.strictEqual(params.IndexName, 'user-index');
+    assert.ok(params.KeyConditionExpression.includes('#userId = :userId'));
+    assert.deepEqual(params.ExpressionAttributeNames, { '#userId': 'userId' });
+    assert.deepEqual(params.ExpressionAttributeValues, { ':userId': 'u1' });
+    assert.strictEqual(params.ExclusiveStartKey, undefined);
+  });
+
+  test('builds query for multiple GSI key conditions joined with AND', function(assert) {
+    const params = buildQuery('orders', 'user-status-index', { userId: 'u1', status: 'open' });
+
+    assert.ok(params.KeyConditionExpression.includes(' AND '), 'AND present for composite key');
+    assert.strictEqual(Object.keys(params.ExpressionAttributeNames).length, 2);
+  });
+
+  test('passes pagination key through', function(assert) {
+    const startKey = { id: 'tok123' };
+    const params = buildQuery('sessions', 'user-index', { userId: 'u1' }, startKey);
+
+    assert.deepEqual(params.ExclusiveStartKey, startKey);
+  });
+});

--- a/test/unit/dynamodb/type-map-test.ts
+++ b/test/unit/dynamodb/type-map-test.ts
@@ -1,0 +1,66 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import { getDynamoType, getDynamoKeyType } from '../../../src/dynamodb/type-map.js';
+
+const { module, test } = QUnit;
+
+module('[Unit] DynamoDB type-map — getDynamoType', function() {
+  test('string maps to S', function(assert) {
+    assert.strictEqual(getDynamoType('string'), 'S');
+  });
+
+  test('number maps to N', function(assert) {
+    assert.strictEqual(getDynamoType('number'), 'N');
+  });
+
+  test('float maps to N', function(assert) {
+    assert.strictEqual(getDynamoType('float'), 'N');
+  });
+
+  test('boolean maps to BOOL', function(assert) {
+    assert.strictEqual(getDynamoType('boolean'), 'BOOL');
+  });
+
+  test('date maps to S (ISO-8601 string for range queries)', function(assert) {
+    assert.strictEqual(getDynamoType('date'), 'S');
+  });
+
+  test('timestamp maps to N', function(assert) {
+    assert.strictEqual(getDynamoType('timestamp'), 'N');
+  });
+
+  test('passthrough maps to S', function(assert) {
+    assert.strictEqual(getDynamoType('passthrough'), 'S');
+  });
+
+  test('unknown type defaults to S', function(assert) {
+    assert.strictEqual(getDynamoType('customTransform'), 'S');
+    assert.strictEqual(getDynamoType(''), 'S');
+  });
+});
+
+module('[Unit] DynamoDB type-map — getDynamoKeyType', function() {
+  test('string maps to S key type', function(assert) {
+    assert.strictEqual(getDynamoKeyType('string'), 'S');
+  });
+
+  test('number maps to N key type', function(assert) {
+    assert.strictEqual(getDynamoKeyType('number'), 'N');
+  });
+
+  test('float maps to N key type', function(assert) {
+    assert.strictEqual(getDynamoKeyType('float'), 'N');
+  });
+
+  test('boolean falls back to S key type (BOOL cannot be a key attribute)', function(assert) {
+    assert.strictEqual(getDynamoKeyType('boolean'), 'S');
+  });
+
+  test('date maps to S key type', function(assert) {
+    assert.strictEqual(getDynamoKeyType('date'), 'S');
+  });
+
+  test('unknown type falls back to S key type', function(assert) {
+    assert.strictEqual(getDynamoKeyType('anything'), 'S');
+  });
+});

--- a/test/unit/dynamodb/type-map-test.ts
+++ b/test/unit/dynamodb/type-map-test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import QUnit from 'qunit';
 import { getDynamoType, getDynamoKeyType } from '../../../src/dynamodb/type-map.js';
 


### PR DESCRIPTION
## Summary

Implements a new DynamoDB driver for `@stonyx/orm` that follows the `SqlDb` PAL contract — config-only swap with zero ORM core behavioral changes.

Closes #128. Research spike: #127. Feasibility doc: `beatrix-shared/projects/stonyx/research/dynamodb-feasibility.md`.

## Changes

### New files (8)
- `src/dynamodb/dynamodb-db.ts` — Full `SqlDb` implementation (767 lines): init, startup, shutdown, persist, findRecord, findAll, GSI routing, ULID generation, memory eviction
- `src/dynamodb/connection.ts` — DynamoDB DocumentClient factory (dynamic import pattern)
- `src/dynamodb/operation-builder.ts` — Pure param builders for PutItem/GetItem/UpdateItem/DeleteItem/Scan/Query
- `src/dynamodb/type-map.ts` — ORM attr types → DynamoDB attribute types
- `test/unit/dynamodb/dynamodb-db-test.ts` — 20 tests for core CRUD + pagination + eviction
- `test/unit/dynamodb/gsi-routing-test.ts` — 10 tests for GSI registry + query routing
- `test/unit/dynamodb/operation-builder-test.ts` — 15 tests for param builders
- `test/unit/dynamodb/type-map-test.ts` — 14 tests for type mapping

### Modified files (4)
- `src/main.ts` — Driver selection: `else if (config.orm.dynamodb)` (+5 lines)
- `src/types/orm-types.ts` — `OrmDynamoDBConfig` interface + `dynamodb?` on `OrmSection` (+7 lines)
- `src/commands.ts` — DynamoDB-aware migration command branching (+43 lines)
- `package.json` — `@aws-sdk/client-dynamodb` + `@aws-sdk/lib-dynamodb` as optional peerDependencies

### Key design decisions
- **Multi-table**: one DynamoDB table per ORM model (mirrors PostgreSQL driver)
- **ULID**: inline Crockford base32 implementation for numeric-ID models (no external dep)
- **GSI routing**: registry built from FK column introspection at init; `findAll()` routes to Query vs Scan
- **Dynamic imports**: AWS SDK loaded only when driver is selected (optional peer deps)
- **Injectable deps**: all SDK commands injectable for test isolation without real AWS SDK

## Test plan

- [x] `pnpm run build` — TypeScript compilation passes
- [x] `pnpm test` — 722 tests pass (59 new DynamoDB tests + 663 existing)
- [x] Zero existing test failures introduced
- [ ] SME review (5 phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)