### PR TITLE
docs: update documentation for DynamoDB driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A lightweight ORM for Stonyx projects, featuring model definitions, serializers,
 - **Models**: Define attributes with type-safe proxies (`attr`) and relationships (`hasMany`, `belongsTo`).
 - **Serializers**: Map raw data into model-friendly structures, including nested properties.
 - **Transforms**: Apply custom transformations on data values automatically.
-- **DB Integration**: Optional file-based persistence with auto-save support, or MySQL for production workloads.
+- **DB Integration**: Optional file-based persistence with auto-save support, or MySQL/PostgreSQL/TimescaleDB/DynamoDB for production workloads.
 - **REST Server Integration**: Automatic route setup with customizable access control.
 - **Lifecycle Hooks**: Middleware-based before/after hooks for validation, authorization, side effects, and auditing.
 
@@ -65,13 +65,16 @@ const {
   MYSQL_DATABASE,
   MYSQL_CONNECTION_LIMIT,
   MYSQL_MIGRATIONS_DIR,
+  DYNAMODB_REGION,
+  DYNAMODB_ENDPOINT,
+  DYNAMODB_TABLE_PREFIX,
 } = process.env;
 
 export default {
   orm: {
     logColor: 'white',
     logMethod: 'db',
-    
+
     db: {
       autosave: DB_AUTO_SAVE ?? 'false',
       file: DB_FILE ?? 'db.json',
@@ -95,6 +98,11 @@ export default {
       connectionLimit: parseInt(MYSQL_CONNECTION_LIMIT ?? '10'),
       migrationsDir: MYSQL_MIGRATIONS_DIR ?? 'migrations',
       migrationsTable: '__migrations',
+    } : undefined,
+    dynamodb: DYNAMODB_REGION ? {
+      region: DYNAMODB_REGION ?? 'us-east-1',
+      endpoint: DYNAMODB_ENDPOINT,          // optional, for DynamoDB Local
+      tablePrefix: DYNAMODB_TABLE_PREFIX,   // optional table name prefix
     } : undefined,
     restServer: {
       enabled: ORM_USE_REST_SERVER ?? 'true',
@@ -243,6 +251,31 @@ Set the `MYSQL_HOST` environment variable to enable MySQL persistence. The ORM l
 | `stonyx db:migrate` | Apply pending migrations |
 | `stonyx db:migrate:rollback` | Rollback the most recent migration |
 | `stonyx db:migrate:status` | Show migration status |
+| `stonyx db:sync` | Sync DynamoDB table definitions to match current model schemas |
+
+### DynamoDB Mode
+
+Set the `DYNAMODB_REGION` environment variable to enable DynamoDB persistence. Tables are created with PAY_PER_REQUEST (on-demand) billing. Global Secondary Indexes (GSIs) are auto-provisioned at startup based on model `belongsTo` relationships — each FK column gets a GSI. `findAll()` with conditions routes to a GSI Query when the condition key matches a GSI partition key; non-indexed attribute conditions fall back to Scan + FilterExpression (expensive for large tables). ULID generation replaces auto-increment for numeric-ID models.
+
+```javascript
+dynamodb: {
+  region: 'us-east-1',
+  endpoint: 'http://localhost:8000', // optional, for DynamoDB Local
+  tablePrefix: 'myapp-',            // optional table name prefix
+}
+```
+
+Environment variables:
+
+* `DYNAMODB_REGION`: AWS region for DynamoDB (e.g., `'us-east-1'`).
+* `DYNAMODB_ENDPOINT`: Optional custom endpoint URL, useful for DynamoDB Local during development.
+* `DYNAMODB_TABLE_PREFIX`: Optional prefix prepended to all table names (e.g., `'myapp-'` yields `'myapp-animals'`).
+
+**Peer dependencies:** `@aws-sdk/client-dynamodb` and `@aws-sdk/lib-dynamodb` must be installed when using the DynamoDB driver. The AWS SDK is dynamically imported and only loaded when the DynamoDB driver is selected.
+
+```bash
+npm install @aws-sdk/client-dynamodb @aws-sdk/lib-dynamodb
+```
 
 ### Running MySQL Tests
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ export default {
       migrationsTable: '__migrations',
     } : undefined,
     dynamodb: DYNAMODB_REGION ? {
-      region: DYNAMODB_REGION ?? 'us-east-1',
+      region: DYNAMODB_REGION,
       endpoint: DYNAMODB_ENDPOINT,          // optional, for DynamoDB Local
       tablePrefix: DYNAMODB_TABLE_PREFIX,   // optional table name prefix
     } : undefined,

--- a/docs/agents/architect.md
+++ b/docs/agents/architect.md
@@ -7,7 +7,7 @@
 
 **Repo:** `abofs/stonyx-orm`
 **Framework:** Data persistence layer for the Stonyx ecosystem
-**Domain:** ORM with model definitions, relationships (hasMany/belongsTo), serializers, transforms, lifecycle hooks, aggregate helpers, views, and multi-backend persistence (JSON file, MySQL, PostgreSQL, TimescaleDB)
+**Domain:** ORM with model definitions, relationships (hasMany/belongsTo), serializers, transforms, lifecycle hooks, aggregate helpers, views, and multi-backend persistence (JSON file, MySQL, PostgreSQL, TimescaleDB, DynamoDB)
 
 ## Tech Stack
 
@@ -16,7 +16,7 @@
 | Language | TypeScript (ES Modules) |
 | Runtime | Node.js |
 | Framework | Stonyx (auto-discovered as `@stonyx/orm` module) |
-| Database Adapters | JSON file (single/directory mode), MySQL (`mysql2`), PostgreSQL (`pg`), TimescaleDB |
+| Database Adapters | JSON file (single/directory mode), MySQL (`mysql2`), PostgreSQL (`pg`), TimescaleDB, DynamoDB (`@aws-sdk/client-dynamodb`, `@aws-sdk/lib-dynamodb`) |
 | Events | `@stonyx/events` (pub/sub for hook system) |
 | Scheduling | `@stonyx/cron` (auto-save intervals) |
 | REST Integration | `@stonyx/rest-server` (optional peer dependency for auto-route registration) |
@@ -41,3 +41,8 @@
 - `oldState` in hooks is captured via `JSON.parse(JSON.stringify())` deep copy before the operation — this means non-serializable values (functions, circular refs) are silently dropped
 - The module waits for `@stonyx/rest-server` via `waitForModule('rest-server')` before mounting routes — if rest-server is not in `devDependencies`, the ORM still works but REST integration is silently skipped
 - PostgreSQL and TimescaleDB adapters share connection and migration infrastructure but TimescaleDB adds hypertable creation and time-partitioned query building
+- DynamoDB driver uses PAY_PER_REQUEST (on-demand) billing mode for all table creation — no capacity planning required
+- GSIs are auto-provisioned at `startup()` based on model `belongsTo` relationships — each FK column gets a dedicated GSI on the owning table
+- `findAll()` with conditions routes to a GSI Query when the condition key matches a GSI partition key; falls back to Scan + FilterExpression for non-indexed attributes (expensive for large tables)
+- ULID generation replaces auto-increment for numeric-ID models when using the DynamoDB driver
+- AWS SDK (`@aws-sdk/client-dynamodb`, `@aws-sdk/lib-dynamodb`) is dynamically imported — only loaded when the DynamoDB driver is selected; no overhead for other backends

--- a/docs/agents/qa-test-engineer.md
+++ b/docs/agents/qa-test-engineer.md
@@ -7,7 +7,7 @@
 
 **Repo:** `abofs/stonyx-orm`
 **Framework:** Data persistence layer for the Stonyx ecosystem
-**Domain:** ORM with model definitions, relationships, serializers, hooks, aggregate helpers, views, and multi-backend persistence
+**Domain:** ORM with model definitions, relationships, serializers, hooks, aggregate helpers, views, and multi-backend persistence (JSON file, MySQL, PostgreSQL, TimescaleDB, DynamoDB)
 
 ## Tech Stack
 
@@ -37,3 +37,8 @@
 - The proxy-based record access means `record.age` and `record.__data.age` can diverge if transforms are involved — test assertions should always use the proxy interface
 - View resolver tests need both source models populated in the store and view definitions registered — views are read-only, so `store.remove()` on a view model name should throw
 - Auto-save tests (`DB_AUTO_SAVE: 'onUpdate'`) need to verify that file writes happen after each mutation and that `DB_AUTO_SAVE: 'true'` uses the cron interval instead
+- DynamoDB unit tests live under `test/unit/dynamodb/` (4 files: `dynamodb-db-test`, `gsi-routing-test`, `operation-builder-test`, `type-map-test`)
+- Shared DynamoDB test helper is at `test/helpers/dynamodb-test-helper.ts`; exports `makeCommandStub`, `makeDocClientCommands`, `createMockDeps`, `resetInstance`, and `buildDb`
+- The `DynamoDBDeps` mock-injection pattern makes all AWS SDK commands injectable via the `deps` argument — tests never import the real AWS SDK, keeping them fully offline
+- Must call `DynamoDBDB.instance = undefined` in `afterEach` to reset the singleton between tests; skipping this causes state bleed identical to the `Orm.instance` / `Store.instance` issue
+- Integration tests against DynamoDB Local are not yet implemented — the unit test suite (with mocked deps) is the only current coverage for the DynamoDB driver


### PR DESCRIPTION
## Summary

Updates README, architect template, and QA template to reflect the DynamoDB driver shipped in #129.

Closes #130.

## Changes
- **README.md** — DynamoDB listed as supported backend, config block documented, env vars documented, `db:sync` added to CLI table, peer dep install guidance
- **docs/agents/architect.md** — DynamoDB in tech stack, 5 live knowledge entries (PAY_PER_REQUEST, GSI auto-provisioning, routing, ULID, dynamic import)
- **docs/agents/qa-test-engineer.md** — DynamoDB test suite info, mock-injection pattern, singleton reset requirement

## Test plan
- [x] No code changes — docs only
- [ ] Combined-phase SME review

🤖 Generated with [Claude Code](https://claude.com/claude-code)