### PR TITLE
feat(orm): pass-through pg.Pool options from consumer config

### DIFF
--- a/src/postgres/connection.ts
+++ b/src/postgres/connection.ts
@@ -8,6 +8,7 @@ interface PgConfig {
   password: string;
   database: string;
   connectionLimit: number;
+  [key: string]: unknown;
 }
 
 let pool: PgPool | null = null;
@@ -20,15 +21,18 @@ export async function getPool(pgConfig: PgConfig, extensions: string[] = ['vecto
 
   const { default: pg } = await import('pg');
 
+  const { host, port, user, password, database, connectionLimit, migrationsDir, migrationsTable, ...poolOpts } = pgConfig;
+
   pool = new pg.Pool({
-    host: pgConfig.host,
-    port: pgConfig.port,
-    user: pgConfig.user,
-    password: pgConfig.password,
-    database: pgConfig.database,
-    max: pgConfig.connectionLimit,
+    host,
+    port,
+    user,
+    password,
+    database,
+    max: connectionLimit,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 10000,
+    ...poolOpts,
   });
 
   // Enable requested PostgreSQL extensions

--- a/test/unit/postgres/connection-pool-options-test.ts
+++ b/test/unit/postgres/connection-pool-options-test.ts
@@ -1,0 +1,127 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import sinon from 'sinon';
+
+const { module, test } = QUnit;
+
+/**
+ * To test getPool() without a real Postgres connection we need to intercept
+ * the `new pg.Pool(...)` call. getPool() does `const { default: pg } = await import('pg')`
+ * so once pg is loaded in the ESM cache, replacing `pg.default.Pool` (or
+ * equivalently `pg.Pool` on the CJS wrapper) lets us capture constructor args.
+ *
+ * Between every test we call closePool() to reset the module-level singleton
+ * so the next getPool() call constructs a fresh Pool.
+ */
+
+let pgModule: any;
+let OriginalPool: any;
+let getPool: typeof import('../../../src/postgres/connection.js').getPool;
+let closePool: typeof import('../../../src/postgres/connection.js').closePool;
+
+module('[Unit] Postgres connection — pool pass-through options', function (hooks) {
+
+  hooks.before(async function () {
+    // Pre-load pg so it's in the ESM cache before getPool() runs
+    pgModule = await import('pg');
+    OriginalPool = pgModule.default.Pool;
+
+    // Import the module under test
+    const conn = await import('../../../src/postgres/connection.js');
+    getPool = conn.getPool;
+    closePool = conn.closePool;
+  });
+
+  hooks.beforeEach(function () {
+    // Replace Pool with a sinon stub that returns a fake pool object
+    const fakePool = {
+      query: sinon.stub().resolves(),
+      end: sinon.stub().resolves(),
+    };
+    pgModule.default.Pool = sinon.stub().returns(fakePool);
+  });
+
+  hooks.afterEach(async function () {
+    // Reset the singleton so each test gets a fresh getPool() call
+    await closePool();
+    sinon.restore();
+  });
+
+  hooks.after(function () {
+    // Restore the original Pool constructor
+    pgModule.default.Pool = OriginalPool;
+  });
+
+  // ── Assertion 1: keepalives pass-through ────────────────────────────
+  test('Pool receives keepalives: true when pgConfig includes it', async function (assert) {
+    await getPool({
+      host: 'localhost', port: 5432, user: 'u', password: 'p',
+      database: 'db', connectionLimit: 5,
+      keepalives: true,
+    }, []);
+
+    const ctorArgs = pgModule.default.Pool.firstCall.args[0];
+    assert.strictEqual(ctorArgs.keepalives, true, 'keepalives passed through');
+  });
+
+  // ── Assertion 2: keepalivesIdle pass-through ────────────────────────
+  test('Pool receives keepalivesIdle: 60 when pgConfig includes it', async function (assert) {
+    await getPool({
+      host: 'localhost', port: 5432, user: 'u', password: 'p',
+      database: 'db', connectionLimit: 5,
+      keepalivesIdle: 60,
+    }, []);
+
+    const ctorArgs = pgModule.default.Pool.firstCall.args[0];
+    assert.strictEqual(ctorArgs.keepalivesIdle, 60, 'keepalivesIdle passed through');
+  });
+
+  // ── Assertion 3: default idleTimeoutMillis preserved ────────────────
+  test('Pool receives idleTimeoutMillis: 30000 when consumer does not override', async function (assert) {
+    await getPool({
+      host: 'localhost', port: 5432, user: 'u', password: 'p',
+      database: 'db', connectionLimit: 5,
+    }, []);
+
+    const ctorArgs = pgModule.default.Pool.firstCall.args[0];
+    assert.strictEqual(ctorArgs.idleTimeoutMillis, 30000, 'default idleTimeoutMillis preserved');
+  });
+
+  // ── Assertion 4: consumer override wins ─────────────────────────────
+  test('Pool receives idleTimeoutMillis: 240000 when consumer overrides it', async function (assert) {
+    await getPool({
+      host: 'localhost', port: 5432, user: 'u', password: 'p',
+      database: 'db', connectionLimit: 5,
+      idleTimeoutMillis: 240000,
+    }, []);
+
+    const ctorArgs = pgModule.default.Pool.firstCall.args[0];
+    assert.strictEqual(ctorArgs.idleTimeoutMillis, 240000, 'consumer override wins');
+  });
+
+  // ── Assertion 5: ORM-only fields stripped ───────────────────────────
+  test('Pool does NOT receive migrationsDir or migrationsTable', async function (assert) {
+    await getPool({
+      host: 'localhost', port: 5432, user: 'u', password: 'p',
+      database: 'db', connectionLimit: 5,
+      migrationsDir: '/some/path',
+      migrationsTable: 'schema_migrations',
+    }, []);
+
+    const ctorArgs = pgModule.default.Pool.firstCall.args[0];
+    assert.false('migrationsDir' in ctorArgs, 'migrationsDir stripped');
+    assert.false('migrationsTable' in ctorArgs, 'migrationsTable stripped');
+  });
+
+  // ── Assertion 6: connectionLimit → max rename preserved ─────────────
+  test('Pool receives max: 10 when connectionLimit: 10', async function (assert) {
+    await getPool({
+      host: 'localhost', port: 5432, user: 'u', password: 'p',
+      database: 'db', connectionLimit: 10,
+    }, []);
+
+    const ctorArgs = pgModule.default.Pool.firstCall.args[0];
+    assert.strictEqual(ctorArgs.max, 10, 'connectionLimit mapped to max');
+    assert.false('connectionLimit' in ctorArgs, 'connectionLimit itself not passed to Pool');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds index signature to `PgConfig` and spreads extra config fields into `pg.Pool()` after hardcoded defaults, so consumers can tune keepalive, idle timeout, and other pool-level knobs via their config without modifying ORM internals
- ORM-only fields (`migrationsDir`, `migrationsTable`) are destructured out so they don't leak into the Pool constructor
- Unblocks nextgoal-data-collector#128 (long-lived collector connections dropping due to default idle timeout)

Closes #79

## Validation assertions

- [x] Pool constructor receives `keepalives: true` when pgConfig includes `keepalives: true`
- [x] Pool constructor receives `keepalivesIdle: 60` when pgConfig includes `keepalivesIdle: 60`
- [x] Pool constructor receives `idleTimeoutMillis: 30000` when consumer does NOT override it (default preserved)
- [x] Pool constructor receives `idleTimeoutMillis: 240000` when consumer sets `idleTimeoutMillis: 240000` (consumer override wins)
- [x] Pool constructor does NOT receive `migrationsDir` or `migrationsTable` keys (ORM-only fields stripped)
- [x] Pool constructor receives `max: 10` when `connectionLimit: 10` (rename mapping preserved)

## Test plan

- [x] Run `npx tsx --test test/unit/postgres/connection-pool-options-test.ts` — all 6 assertions pass
- [x] Run full unit suite — no regressions (pre-existing Stonyx init failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)