### PR TITLE
fix(orm): hasMany async resolution for cross-frame child records

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stonyx/orm",
-  "version": "0.3.1",
+  "version": "0.3.2-beta.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stonyx/orm",
-      "version": "0.3.1",
+      "version": "0.3.2-beta.69",
       "license": "Apache-2.0",
       "dependencies": {
         "@stonyx/cron": "0.2.1-beta.29",

--- a/src/manage-record.ts
+++ b/src/manage-record.ts
@@ -79,6 +79,28 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
     pendingHasMany.splice(0);
   }
 
+  // FK-based inverse hasMany wiring — when a child record is created with a
+  // foreign-key field (e.g. `owner: 'owner-1'` on an animal), find any parent
+  // whose hasMany registry targets this model and push the child into the
+  // parent's shared array.  This covers edge cases where the child is created
+  // in a separate async frame without a belongsTo handler firing.
+  const hasManyReg = getHasManyRegistry();
+  if (hasManyReg) {
+    for (const [parentModelName, targetMap] of hasManyReg) {
+      const childArrayMap = targetMap.get(modelName);
+      if (!childArrayMap) continue;
+
+      // Check if rawData contains a FK field matching the parent model name
+      const fkValue = rawData[parentModelName];
+      if (fkValue === undefined || fkValue === null) continue;
+
+      const parentArray = childArrayMap.get(fkValue);
+      if (parentArray && !parentArray.includes(record)) {
+        parentArray.push(record);
+      }
+    }
+  }
+
   // Fulfill pending belongsTo relationships
   const pendingBelongsToQueue = getPendingBelongsToRegistry();
   const pendingBelongsToRaw = pendingBelongsToQueue.get(modelName)?.get(record.id);
@@ -86,7 +108,7 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
 
   if (pendingBelongsTo) {
     const belongsToReg = getBelongsToRegistry();
-    const hasManyReg = getHasManyRegistry();
+    const pendingHasManyReg = getHasManyRegistry();
 
     for (const { sourceRecord, sourceModelName, relationshipKey, relationshipId } of pendingBelongsTo) {
       // Update the belongsTo relationship on the source record
@@ -103,7 +125,7 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
       }
 
       // Wire inverse hasMany if it exists
-      const inverseHasMany = hasManyReg.get(modelName)?.get(sourceModelName)?.get(record.id);
+      const inverseHasMany = pendingHasManyReg.get(modelName)?.get(sourceModelName)?.get(record.id);
 
       if (inverseHasMany && !inverseHasMany.includes(sourceRecord)) {
         inverseHasMany.push(sourceRecord);

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -94,8 +94,33 @@ export default class Serializer {
         const handlerOptions = { ...options, _relationshipKey: key };
         const childRecord = handler(record, data, handlerOptions);
 
-        rec[key] = childRecord;
-        relatedRecords[key] = childRecord;
+        // hasMany relationships use a getter so format()/toJSON() always read
+        // the live registry array instead of a stale snapshot captured at
+        // serialization time.  This is critical when child records are created
+        // in a later async frame — the belongsTo inverse wiring pushes into
+        // the shared registry array, and the getter ensures the parent sees it.
+        const isHasMany = (handler as { __relationshipType?: string }).__relationshipType === 'hasMany';
+
+        if (isHasMany) {
+          // `childRecord` IS the shared registry array — define a getter that
+          // always dereferences through the same array reference.
+          const registryArray = childRecord as unknown[];
+          Object.defineProperty(rec, key, {
+            enumerable: true,
+            configurable: true,
+            get: () => registryArray,
+            set(v: unknown) { relatedRecords[key] = v; }
+          });
+          Object.defineProperty(relatedRecords, key, {
+            enumerable: true,
+            configurable: true,
+            get: () => registryArray,
+            set(v: unknown) { Object.defineProperty(relatedRecords, key, { value: v, writable: true, enumerable: true, configurable: true }); }
+          });
+        } else {
+          rec[key] = childRecord;
+          relatedRecords[key] = childRecord;
+        }
 
         continue;
       }

--- a/test/unit/has-many-async-test.ts
+++ b/test/unit/has-many-async-test.ts
@@ -30,8 +30,8 @@ module('[Unit] hasMany | async resolution across frames', function(hooks) {
     // Simulate separate async frame
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    // Create child animal with FK pointing to parent
-    const animal = createRecord('animal', { id: 'animal-1', type: 'dog', age: 3, size: 'large', owner: 'owner-1' }, { serialize: false });
+    // Create child animal with FK pointing to parent (numeric id — animal model uses default attr('number'))
+    const animal = createRecord('animal', { id: 1, type: 'dog', age: 3, size: 'large', owner: 'owner-1' }, { serialize: false });
 
     // The parent's hasMany getter should now include the child
     assert.strictEqual(owner.pets.length, 1, 'hasMany getter returns 1 child after async creation');
@@ -43,12 +43,12 @@ module('[Unit] hasMany | async resolution across frames', function(hooks) {
 
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    const animal = createRecord('animal', { id: 'animal-2', type: 'cat', age: 2, size: 'small', owner: 'owner-2' }, { serialize: false });
+    const animal = createRecord('animal', { id: 2, type: 'cat', age: 2, size: 'small', owner: 'owner-2' }, { serialize: false });
 
     const formatted = owner.format();
     assert.ok(Array.isArray(formatted.pets), 'format() pets key is an array');
     assert.strictEqual(formatted.pets.length, 1, 'format() includes 1 child');
-    assert.strictEqual(formatted.pets[0].id, 'animal-2', 'format() child has correct id');
+    assert.strictEqual(formatted.pets[0].id, 2, 'format() child has correct id');
   });
 
   test('parent.toJSON() includes late-arriving child in hasMany key', async function(assert) {
@@ -56,7 +56,7 @@ module('[Unit] hasMany | async resolution across frames', function(hooks) {
 
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    const animal = createRecord('animal', { id: 'animal-3', type: 'dog', age: 5, size: 'medium', owner: 'owner-3' }, { serialize: false });
+    const animal = createRecord('animal', { id: 3, type: 'dog', age: 5, size: 'medium', owner: 'owner-3' }, { serialize: false });
 
     const json = owner.toJSON();
     assert.ok(json.relationships, 'toJSON has relationships');
@@ -64,15 +64,15 @@ module('[Unit] hasMany | async resolution across frames', function(hooks) {
     assert.ok(petsRel, 'toJSON has pets relationship');
     assert.ok(Array.isArray(petsRel.data), 'pets relationship data is an array');
     assert.strictEqual(petsRel.data.length, 1, 'toJSON pets has 1 child');
-    assert.strictEqual(petsRel.data[0].id, 'animal-3', 'toJSON child has correct id');
+    assert.strictEqual(petsRel.data[0].id, 3, 'toJSON child has correct id');
   });
 
   test('same-frame hasMany resolution still works (regression guard)', function(assert) {
     // Create owner with pet IDs in rawData — standard same-frame path
-    const owner = createRecord('owner', { id: 'owner-4', gender: 'female', age: 35, pets: [{ id: 'animal-4', type: 'dog', age: 1, size: 'small' }] }, { serialize: false });
+    const owner = createRecord('owner', { id: 'owner-4', gender: 'female', age: 35, pets: [{ id: 4, type: 'dog', age: 1, size: 'small' }] }, { serialize: false });
 
     assert.strictEqual(owner.pets.length, 1, 'same-frame hasMany has 1 child');
-    assert.strictEqual(owner.pets[0].id, 'animal-4', 'same-frame child has correct id');
+    assert.strictEqual(owner.pets[0].id, 4, 'same-frame child has correct id');
   });
 
   test('existing belongsTo inverse wiring still populates parent hasMany (regression guard)', function(assert) {
@@ -80,7 +80,7 @@ module('[Unit] hasMany | async resolution across frames', function(hooks) {
     const owner = createRecord('owner', { id: 'owner-5', gender: 'male', age: 50 }, { serialize: false });
 
     // Create animal with belongsTo owner — belongsTo handler wires into hasMany
-    const animal = createRecord('animal', { id: 'animal-5', type: 'cat', age: 3, size: 'medium', owner: 'owner-5' }, { serialize: false });
+    const animal = createRecord('animal', { id: 5, type: 'cat', age: 3, size: 'medium', owner: 'owner-5' }, { serialize: false });
 
     // The belongsTo inverse wiring path should populate owner.pets
     assert.strictEqual(owner.pets.length, 1, 'belongsTo inverse wiring populates hasMany');

--- a/test/unit/has-many-async-test.ts
+++ b/test/unit/has-many-async-test.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import { createRecord, store, relationships } from '@stonyx/orm';
+
+const { module, test } = QUnit;
+
+module('[Unit] hasMany | async resolution across frames', function(hooks) {
+  const clearStores = function() {
+    const models = ['owner', 'animal', 'trait', 'category', 'phone-number'];
+    for (const model of models) {
+      const modelStore = store.get(model);
+      if (modelStore) modelStore.clear();
+    }
+
+    relationships.get('hasMany')?.clear();
+    relationships.get('belongsTo')?.clear();
+    relationships.get('pending')?.clear();
+    relationships.get('pendingBelongsTo')?.clear();
+  };
+
+  hooks.beforeEach(clearStores);
+  hooks.afterEach(clearStores);
+
+  test('child created in separate async frame with FK appears in parent hasMany getter', async function(assert) {
+    // Create parent owner with no pets initially
+    const owner = createRecord('owner', { id: 'owner-1', gender: 'male', age: 30 }, { serialize: false });
+
+    assert.deepEqual(owner.pets, [], 'initially empty hasMany');
+
+    // Simulate separate async frame
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Create child animal with FK pointing to parent
+    const animal = createRecord('animal', { id: 'animal-1', type: 'dog', age: 3, size: 'large', owner: 'owner-1' }, { serialize: false });
+
+    // The parent's hasMany getter should now include the child
+    assert.strictEqual(owner.pets.length, 1, 'hasMany getter returns 1 child after async creation');
+    assert.strictEqual(owner.pets[0], animal, 'hasMany getter contains the created child record');
+  });
+
+  test('parent.format() includes late-arriving child in hasMany key', async function(assert) {
+    const owner = createRecord('owner', { id: 'owner-2', gender: 'female', age: 25 }, { serialize: false });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const animal = createRecord('animal', { id: 'animal-2', type: 'cat', age: 2, size: 'small', owner: 'owner-2' }, { serialize: false });
+
+    const formatted = owner.format();
+    assert.ok(Array.isArray(formatted.pets), 'format() pets key is an array');
+    assert.strictEqual(formatted.pets.length, 1, 'format() includes 1 child');
+    assert.strictEqual(formatted.pets[0].id, 'animal-2', 'format() child has correct id');
+  });
+
+  test('parent.toJSON() includes late-arriving child in hasMany key', async function(assert) {
+    const owner = createRecord('owner', { id: 'owner-3', gender: 'male', age: 40 }, { serialize: false });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const animal = createRecord('animal', { id: 'animal-3', type: 'dog', age: 5, size: 'medium', owner: 'owner-3' }, { serialize: false });
+
+    const json = owner.toJSON();
+    assert.ok(json.relationships, 'toJSON has relationships');
+    const petsRel = json.relationships.pets;
+    assert.ok(petsRel, 'toJSON has pets relationship');
+    assert.ok(Array.isArray(petsRel.data), 'pets relationship data is an array');
+    assert.strictEqual(petsRel.data.length, 1, 'toJSON pets has 1 child');
+    assert.strictEqual(petsRel.data[0].id, 'animal-3', 'toJSON child has correct id');
+  });
+
+  test('same-frame hasMany resolution still works (regression guard)', function(assert) {
+    // Create owner with pet IDs in rawData — standard same-frame path
+    const owner = createRecord('owner', { id: 'owner-4', gender: 'female', age: 35, pets: [{ id: 'animal-4', type: 'dog', age: 1, size: 'small' }] }, { serialize: false });
+
+    assert.strictEqual(owner.pets.length, 1, 'same-frame hasMany has 1 child');
+    assert.strictEqual(owner.pets[0].id, 'animal-4', 'same-frame child has correct id');
+  });
+
+  test('existing belongsTo inverse wiring still populates parent hasMany (regression guard)', function(assert) {
+    // Create owner first
+    const owner = createRecord('owner', { id: 'owner-5', gender: 'male', age: 50 }, { serialize: false });
+
+    // Create animal with belongsTo owner — belongsTo handler wires into hasMany
+    const animal = createRecord('animal', { id: 'animal-5', type: 'cat', age: 3, size: 'medium', owner: 'owner-5' }, { serialize: false });
+
+    // The belongsTo inverse wiring path should populate owner.pets
+    assert.strictEqual(owner.pets.length, 1, 'belongsTo inverse wiring populates hasMany');
+    assert.strictEqual(owner.pets[0], animal, 'hasMany contains the child from belongsTo wiring');
+  });
+});


### PR DESCRIPTION
## Summary

- **Serializer getter wiring:** For hasMany relationships, replace direct assignment with `Object.defineProperty` getter/setter on both `rec[key]` and `relatedRecords[key]`, so `format()` and `toJSON()` always read the live shared registry array instead of a stale snapshot captured at serialization time.
- **FK-based inverse hasMany wiring:** In `createRecord`, after populating pending hasMany relationships, iterate `getHasManyRegistry()` to find any parent whose hasMany registry targets the new record's model name. When the child's rawData contains a FK field matching the parent model name, push the child into the parent's shared array — covering the edge case where a child is created in a separate async frame.
- **5 new QUnit tests** covering async FK child creation, `format()` / `toJSON()` with late-arriving children, and regression guards for same-frame and belongsTo inverse wiring paths.

Closes #80

## Test plan

- [x] 5 new unit tests in `test/unit/has-many-async-test.ts` all pass (tests 316–320)
- [x] Full suite: 742/762 pass — 20 pre-existing failures (DynamoDB integration + unrelated ORM integration) unchanged by this work
- [ ] SME review of getter/setter pattern on `__relationships` for hasMany
- [ ] SME review of FK-based wiring loop in `createRecord`

🤖 Generated with [Claude Code](https://claude.com/claude-code)