### PR TITLE
fix: evict memory:false records from store after createRecord persist (#81)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stonyx/orm",
-  "version": "0.3.1",
+  "version": "0.3.2-beta.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stonyx/orm",
-      "version": "0.3.1",
+      "version": "0.3.2-beta.69",
       "license": "Apache-2.0",
       "dependencies": {
         "@stonyx/cron": "0.2.1-beta.29",

--- a/src/manage-record.ts
+++ b/src/manage-record.ts
@@ -118,14 +118,22 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
   const shouldPersist = orm?.sqlDb && !options.isDbRecord && !userOptions._relationshipKey && !options._skipAutoPersist;
   if (shouldPersist) {
     const response = { data: { id: record.id } };
-    orm!.sqlDb!.persist('create', modelName, { rawData }, response).catch((err: unknown) => {
-      orm!.emitPersistError({
-        operation: 'create',
-        modelName,
-        recordId: record.id,
-        error: err instanceof Error ? err : new Error(String(err)),
+    orm!.sqlDb!.persist('create', modelName, { rawData }, response)
+      .catch((err: unknown) => {
+        orm!.emitPersistError({
+          operation: 'create',
+          modelName,
+          recordId: record.id,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      })
+      .finally(() => {
+        // Evict non-memory records after persist to prevent unbounded heap growth (stonyx#81)
+        if (store._memoryResolver && !store._memoryResolver(modelName)) {
+          const ms = store.get(modelName);
+          if (ms) ms.delete(record.id as number | string);
+        }
       });
-    });
   }
 
   return record;

--- a/test/unit/create-record-memory-eviction-test.ts
+++ b/test/unit/create-record-memory-eviction-test.ts
@@ -1,0 +1,107 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import Orm, { createRecord, store } from '@stonyx/orm';
+
+const { module, test } = QUnit;
+
+module('[Unit] createRecord | memory:false eviction (stonyx#81)', function(hooks) {
+  hooks.afterEach(function() {
+    store.get('owner')?.clear();
+    sinon.restore();
+  });
+
+  test('memory:false model record is evicted from store after persist', async function(assert) {
+    // Set up memory resolver — owner is memory:false
+    store._memoryResolver = () => false;
+
+    // Mock sqlDb with a persist that resolves
+    const persistStub = sinon.stub().resolves();
+    const origSqlDb = Orm.instance?.sqlDb;
+    if (Orm.instance) Orm.instance.sqlDb = { persist: persistStub };
+
+    const record = createRecord('owner', { id: 'evict-test', gender: 'female', age: 30 }, { serialize: false });
+
+    // Record exists immediately after createRecord (persist hasn't completed yet)
+    assert.ok(record, 'record returned to caller');
+    assert.strictEqual(record.gender, 'female', 'record has correct data');
+
+    // Wait for persist + finally to complete
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Record should be evicted from store
+    assert.notOk(store.get('owner')?.has('evict-test'), 'record evicted from store after persist');
+
+    // Restore
+    store._memoryResolver = null;
+    if (Orm.instance) Orm.instance.sqlDb = origSqlDb;
+  });
+
+  test('memory:true model record is retained in store after persist', async function(assert) {
+    store._memoryResolver = () => true;
+
+    const persistStub = sinon.stub().resolves();
+    const origSqlDb = Orm.instance?.sqlDb;
+    if (Orm.instance) Orm.instance.sqlDb = { persist: persistStub };
+
+    const record = createRecord('owner', { id: 'retain-test', gender: 'male', age: 25 }, { serialize: false });
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    assert.ok(store.get('owner')?.has('retain-test'), 'record retained in store for memory:true');
+
+    store._memoryResolver = null;
+    if (Orm.instance) Orm.instance.sqlDb = origSqlDb;
+  });
+
+  test('caller reference remains valid after eviction', async function(assert) {
+    store._memoryResolver = () => false;
+
+    const persistStub = sinon.stub().resolves();
+    const origSqlDb = Orm.instance?.sqlDb;
+    if (Orm.instance) Orm.instance.sqlDb = { persist: persistStub };
+
+    const record = createRecord('owner', { id: 'ref-test', gender: 'female', age: 42 }, { serialize: false });
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Record evicted from store but caller reference still valid
+    assert.notOk(store.get('owner')?.has('ref-test'), 'record evicted from store');
+    assert.strictEqual(record.gender, 'female', 'caller reference still has correct data');
+    assert.strictEqual(record.id, 'ref-test', 'caller reference still has correct id');
+
+    store._memoryResolver = null;
+    if (Orm.instance) Orm.instance.sqlDb = origSqlDb;
+  });
+
+  test('persist error still evicts record and emits error', async function(assert) {
+    store._memoryResolver = () => false;
+
+    const persistError = new Error('DB connection lost');
+    const persistStub = sinon.stub().rejects(persistError);
+    const emitStub = sinon.stub();
+    const origSqlDb = Orm.instance?.sqlDb;
+    const origEmit = Orm.instance?.emitPersistError;
+    if (Orm.instance) {
+      Orm.instance.sqlDb = { persist: persistStub };
+      Orm.instance.emitPersistError = emitStub;
+    }
+
+    const record = createRecord('owner', { id: 'err-test', gender: 'male', age: 50 }, { serialize: false });
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // Error was emitted
+    assert.ok(emitStub.calledOnce, 'emitPersistError called');
+    assert.strictEqual(emitStub.firstCall.args[0].operation, 'create', 'error has correct operation');
+
+    // Record still evicted from store
+    assert.notOk(store.get('owner')?.has('err-test'), 'record evicted even after persist error');
+
+    store._memoryResolver = null;
+    if (Orm.instance) {
+      Orm.instance.sqlDb = origSqlDb;
+      Orm.instance.emitPersistError = origEmit;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes stonyx#81: `createRecord` unconditionally retained records in the in-memory store even for `memory: false` models, causing unbounded heap growth (~1,300 records/min) and eventual OOM crashes in long-running consumers
- Chains a `.finally()` eviction callback after the SQL persist promise in `createRecord`, using the existing `_memoryResolver` pattern to remove non-memory records from the store once persist completes
- Unblocks nextgoal-data-collector#213

## Changes
- `src/manage-record.ts`: Added `.finally()` block after persist promise to evict `memory: false` records from the store
- `test/unit/create-record-memory-eviction-test.ts`: 4 new unit tests covering eviction on success, retention for `memory: true`, caller reference validity after eviction, and eviction after persist error

## Test plan
- [x] All 761 tests pass (0 failures)
- [x] `memory:false` model record is evicted from store after persist
- [x] `memory:true` model record is retained in store after persist
- [x] Caller reference remains valid after eviction
- [x] Persist error still evicts record and emits error

🤖 Generated with [Claude Code](https://claude.com/claude-code)