### PR TITLE
fix: use registry-time ID for relationship cleanup on eviction

### DIFF
--- a/src/manage-record.ts
+++ b/src/manage-record.ts
@@ -139,6 +139,9 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
   // Auto-persist to SQL — skip for DB loads (isDbRecord) and relationship resolution (_relationshipKey)
   const shouldPersist = orm?.sqlDb && !options.isDbRecord && !userOptions._relationshipKey && !options._skipAutoPersist;
   if (shouldPersist) {
+    // Capture ID before persist — SQL adapters re-key pending IDs to real DB IDs,
+    // but relationship registries were keyed with this original ID
+    const registryId = record.id;
     const response = { data: { id: record.id } };
     orm!.sqlDb!.persist('create', modelName, { rawData }, response)
       .catch((err: unknown) => {
@@ -152,7 +155,7 @@ export function createRecord(modelName: string, rawData: { [key: string]: unknow
       .finally(() => {
         // Evict non-memory records after persist to prevent unbounded heap growth (stonyx#81)
         if (store._memoryResolver && !store._memoryResolver(modelName)) {
-          store.evictRecord(modelName, record.id);
+          store.evictRecord(modelName, record.id, registryId);
         }
       });
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -197,8 +197,12 @@ export default class Store {
    * Evict a record from the store with full relationship registry cleanup,
    * WITHOUT calling record.clean(). This preserves the caller's reference
    * to the returned record (used by memory:false post-persist eviction).
+   *
+   * @param registryId - The ID used when the record's relationships were
+   *   registered. For SQL models with pending IDs, this is the original
+   *   negative pending ID (before the adapter re-keyed to the real DB ID).
    */
-  evictRecord(modelName: string, id: unknown): void {
+  evictRecord(modelName: string, id: unknown, registryId?: unknown): void {
     const modelStore = this.data.get(modelName);
     if (!modelStore) return;
 
@@ -207,9 +211,22 @@ export default class Store {
     if (!raw || !isStoreRecord(raw)) return;
 
     const visited = new Set([`${modelName}:${id}`]);
+
+    // Remove from hasMany arrays and nullify belongsTo references using current ID
+    // (the adapter updates record.id, so value-based matches need the current ID)
     this._removeFromHasManyArrays(modelName, id, visited);
     this._nullifyBelongsToReferences(modelName, id, visited);
-    this._cleanupRelationshipRegistries(modelName, id);
+
+    // Clean up relationship registry entries using the registry key
+    // (belongsTo/hasMany registries were keyed by the ID at registration time,
+    // which may differ from the current ID if SQL persist re-keyed the record)
+    const cleanupId = registryId ?? id;
+    this._cleanupRelationshipRegistries(modelName, cleanupId);
+
+    // If registryId differs from id, also clean with current id as safety net
+    if (registryId !== undefined && registryId !== id) {
+      this._cleanupRelationshipRegistries(modelName, id);
+    }
 
     modelStore.delete(id);
   }

--- a/test/unit/create-record-memory-eviction-test.ts
+++ b/test/unit/create-record-memory-eviction-test.ts
@@ -158,6 +158,74 @@ module('[Unit] createRecord | memory:false eviction (stonyx#81)', function(hooks
     if (Orm.instance) Orm.instance.sqlDb = origSqlDb;
   });
 
+  test('belongsTo registry cleaned when persist re-keys record ID (stonyx#82 follow-up)', async function(assert) {
+    store._memoryResolver = () => false;
+
+    // Mock sqlDb that simulates the adapter's re-key behavior:
+    // after persist, updates record.id and re-keys the store Map
+    const persistStub = sinon.stub().callsFake(async (operation, modelName, context, response) => {
+      if (operation === 'create' && context.rawData?.__pendingSqlId) {
+        const record = store.get(modelName)?.get(context.rawData.id);
+        if (record) {
+          const pendingId = record.id;
+          const realId = 99999; // Simulate DB-assigned ID
+          const modelStore = store.get(modelName);
+
+          // This is exactly what postgres-db.ts / mysql-db.ts do:
+          modelStore.delete(pendingId);
+          record.__data.id = realId;
+          record.id = realId;
+          modelStore.set(realId, record);
+
+          if (response?.data) response.data.id = realId;
+          delete record.__data.__pendingSqlId;
+        }
+      }
+    });
+
+    const origSqlDb = Orm.instance?.sqlDb;
+    if (Orm.instance) Orm.instance.sqlDb = { persist: persistStub };
+
+    // Create owner first (parent must exist for non-pending belongsTo path)
+    const owner = createRecord('owner', { id: 'owner-rekey-1', gender: 'male', age: 40 }, { serialize: false });
+
+    // Create animal WITHOUT a preset ID — this triggers assignRecordId to assign
+    // a pending negative ID, which the mock persist will re-key to 99999
+    const animal = createRecord('animal', { age: 3, size: 'medium', owner: 'owner-rekey-1' }, { serialize: false });
+
+    // Verify a pending ID was assigned (negative)
+    // Note: record.id may have already been re-keyed by the time we check,
+    // but the registry should still be cleaned regardless
+
+    // Wait for persist + re-key + eviction
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // The belongsTo registry should be clean — no entries for the evicted animal
+    // (whether keyed by the pending ID OR the real ID)
+    const belongsToAnimal = relationships.get('belongsTo')?.get('animal');
+    if (belongsToAnimal) {
+      const ownerRef = belongsToAnimal.get('owner');
+      if (ownerRef) {
+        // Neither the pending ID nor the real ID should remain
+        let zombieCount = 0;
+        for (const [key] of ownerRef) {
+          zombieCount++;
+        }
+        assert.strictEqual(zombieCount, 0, 'no zombie belongsTo entries remain after re-keyed eviction');
+      } else {
+        assert.ok(true, 'owner target map cleaned up entirely');
+      }
+    } else {
+      assert.ok(true, 'animal belongsTo map cleaned up entirely');
+    }
+
+    // Also verify the record was evicted from the store
+    assert.notOk(store.get('animal')?.has(99999), 'record evicted from store (real ID)');
+
+    store._memoryResolver = null;
+    if (Orm.instance) Orm.instance.sqlDb = origSqlDb;
+  });
+
   test('persist error still evicts record and emits error', async function(assert) {
     store._memoryResolver = () => false;
 


### PR DESCRIPTION
## Summary

Follow-up fix for abofs/stonyx#82 — PR #140's eviction cleanup used `record.id` at eviction time, but the SQL adapters (postgres, mysql, dynamodb) re-key records from pending negative IDs to real DB IDs BEFORE the `.finally()` eviction runs. The belongsTo registry was keyed with the pending ID, so `_cleanupRelationshipRegistries(modelName, realId)` missed the entry.

**Root cause:** ID identity mismatch between registration time (pending `-N`) and eviction time (real DB `123`).

**Fix:**
- Capture `record.id` before `persist()` call as `registryId` (the pending ID used to key registries)
- Pass `registryId` to `evictRecord()` for key-based registry cleanup
- Value-based matches (`_removeFromHasManyArrays`, `_nullifyBelongsToReferences`) continue using current `id` since the adapter updates `record.id`
- Safety-net: also runs `_cleanupRelationshipRegistries(id)` when `registryId !== id`

Fixes abofs/stonyx#82 (verification failure on beta.77)

## Test plan

- [x] All 772 tests pass (`pnpm test`)
- [x] New regression test simulates exact adapter re-key behavior (delete pending key, update record.id, set real key)
- [x] Verifies zero zombie entries in belongsTo registry after re-keyed eviction
- [x] All previous eviction tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>