### PR TITLE
fix: clean pendingBelongsTo registry in both directions on eviction

### DIFF
--- a/src/relationships.ts
+++ b/src/relationships.ts
@@ -51,4 +51,4 @@ export function getPendingBelongsToRegistry(): PendingBelongsToMap {
   return relationships.get('pendingBelongsTo') as PendingBelongsToMap;
 }
 
-export const TYPES: string[] = ['global', 'hasMany', 'belongsTo', 'pending'];
+export const TYPES: string[] = ['global', 'hasMany', 'belongsTo', 'pending', 'pendingBelongsTo'];

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,5 @@
 import Orm, { relationships } from '@stonyx/orm';
-import { TYPES, getHasManyRegistry, getBelongsToRegistry, getPendingRegistry } from './relationships.js';
+import { TYPES, getHasManyRegistry, getBelongsToRegistry, getPendingRegistry, getPendingBelongsToRegistry } from './relationships.js';
 import ViewResolver from './view-resolver.js';
 
 interface UnloadOptions {
@@ -346,6 +346,30 @@ export default class Store {
 
     const pendingMap = getPendingRegistry().get(modelName);
     if (pendingMap) pendingMap.delete(recordId);
+
+    // Clean pendingBelongsTo entries in both directions
+    const pendingBelongsToMap = getPendingBelongsToRegistry();
+    if (pendingBelongsToMap) {
+      // Direction 1: evicted record was the TARGET others were waiting for
+      const targetEntries = pendingBelongsToMap.get(modelName);
+      if (targetEntries) targetEntries.delete(recordId);
+
+      // Direction 2: evicted record was the SOURCE with unresolved forward-references
+      for (const [, targetIdMap] of pendingBelongsToMap) {
+        for (const [targetId, entries] of targetIdMap) {
+          if (!Array.isArray(entries)) continue;
+          const filtered = entries.filter((e: unknown) => {
+            const entry = e as { sourceModelName?: string; relationshipId?: unknown };
+            return !(entry.sourceModelName === modelName && entry.relationshipId === recordId);
+          });
+          if (filtered.length === 0) {
+            targetIdMap.delete(targetId);
+          } else if (filtered.length < entries.length) {
+            targetIdMap.set(targetId, filtered);
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/test/unit/create-record-memory-eviction-test.ts
+++ b/test/unit/create-record-memory-eviction-test.ts
@@ -256,4 +256,67 @@ module('[Unit] createRecord | memory:false eviction (stonyx#81)', function(hooks
       Orm.instance.emitPersistError = origEmit;
     }
   });
+
+  test('pendingBelongsTo cleaned when source record is evicted (stonyx#83)', async function(assert) {
+    store._memoryResolver = () => false;
+
+    const persistStub = sinon.stub().resolves();
+    const origSqlDb = Orm.instance?.sqlDb;
+    if (Orm.instance) Orm.instance.sqlDb = { persist: persistStub };
+
+    // Create animal with forward-reference to non-existent owner
+    const animal = createRecord('animal', { id: 904, age: 3, size: 'medium', owner: 'pending-owner-1' }, { serialize: false });
+
+    // Verify pendingBelongsTo entry exists before eviction
+    const pendingBT = relationships.get('pendingBelongsTo');
+    assert.ok(pendingBT?.get('owner')?.has('pending-owner-1'), 'pendingBelongsTo entry exists before eviction');
+
+    // Wait for persist + eviction
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // After eviction, the pendingBelongsTo entry for this animal should be cleaned
+    const ownerPending = pendingBT?.get('owner')?.get('pending-owner-1');
+    const hasAnimalEntry = Array.isArray(ownerPending) && ownerPending.some(
+      (e) => e.sourceModelName === 'animal' && e.relationshipId === 904
+    );
+    assert.notOk(hasAnimalEntry, 'pendingBelongsTo source entry cleaned after eviction');
+
+    // Animal evicted from store
+    assert.notOk(store.get('animal')?.has(904), 'animal evicted from store');
+
+    store._memoryResolver = null;
+    if (Orm.instance) Orm.instance.sqlDb = origSqlDb;
+  });
+
+  test('pendingBelongsTo cleaned when target record is evicted (stonyx#83)', async function(assert) {
+    store._memoryResolver = () => false;
+
+    const persistStub = sinon.stub().resolves();
+    const origSqlDb = Orm.instance?.sqlDb;
+    if (Orm.instance) Orm.instance.sqlDb = { persist: persistStub };
+
+    // Create owner, then create a second animal with forward-ref to a different owner ID
+    const owner = createRecord('owner', { id: 'target-owner-1', gender: 'male', age: 45 }, { serialize: false });
+
+    // Create a pending entry by referencing a non-existent owner from a memory:true context
+    // Actually, let's test the target cleanup directly by manipulating the registry
+    const pendingBT = relationships.get('pendingBelongsTo') || new Map();
+    if (!relationships.has('pendingBelongsTo')) relationships.set('pendingBelongsTo', pendingBT);
+
+    const ownerMap = new Map();
+    ownerMap.set('target-owner-1', [{ sourceRecord: {}, sourceModelName: 'animal', relationshipKey: 'owner', relationshipId: 999 }]);
+    pendingBT.set('owner', ownerMap);
+
+    // Verify entry exists
+    assert.ok(pendingBT.get('owner')?.has('target-owner-1'), 'target entry exists before eviction');
+
+    // Wait for persist + eviction of owner
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    // After owner eviction, the pendingBelongsTo entry keyed by target-owner-1 should be cleaned
+    assert.notOk(pendingBT.get('owner')?.has('target-owner-1'), 'pendingBelongsTo target entry cleaned after eviction');
+
+    store._memoryResolver = null;
+    if (Orm.instance) Orm.instance.sqlDb = origSqlDb;
+  });
 });


### PR DESCRIPTION
## Summary

Fixes abofs/stonyx#83 — `_cleanupRelationshipRegistries` omitted `pendingBelongsTo`. Previous attempt (PR #142, closed) had inverted map traversal — only handled target lookup but the registry is keyed by target model name.

This version handles both directions:
1. **Target eviction** — `pendingBelongsToMap.get(modelName)?.delete(recordId)` removes entries when the record others were waiting for is evicted
2. **Source eviction** — iterates all target buckets and filters entries where `sourceModelName === modelName && relationshipId === recordId`

Also adds `'pendingBelongsTo'` to `TYPES` so `unloadAllRecords` cleans it.

Closes abofs/stonyx#83

## Test plan

- [x] All 774 tests pass (`pnpm test`)
- [x] Source eviction test: creates animal with forward-ref to non-existent owner, asserts pendingBelongsTo entry is removed after eviction
- [x] Target eviction test: seeds a pending entry, asserts it's cleaned when the target record is evicted
- [x] Both tests assert post-eviction registry state (not just store eviction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>