### PR TITLE
fix: remove schema type guard from DynamoDB Date serialization (#148)

### DIFF
--- a/src/dynamodb/dynamodb-db.ts
+++ b/src/dynamodb/dynamodb-db.ts
@@ -525,7 +525,7 @@ export default class DynamoDBDB {
       if (currentData[col] !== oldState[col]) {
         const value = currentData[col] ?? null;
         // Date objects must be serialized to ISO-8601 strings for DynamoDB 'S' storage
-        changedData[col] = (schema.columns[col] === 'date' && value instanceof Date)
+        changedData[col] = (value instanceof Date)
           ? value.toISOString()
           : value;
       }
@@ -746,7 +746,7 @@ export default class DynamoDBDB {
       if (data[col] !== undefined) {
         const value = data[col];
         // Date objects must be serialized to ISO-8601 strings for DynamoDB 'S' storage
-        item[col] = (schema.columns[col] === 'date' && value instanceof Date)
+        item[col] = (value instanceof Date)
           ? value.toISOString()
           : value;
       }


### PR DESCRIPTION
## Summary

P0 hotfix. The Date serialization fix from #144 (PR #146) checked `schema.columns[col] === 'date'`, but `introspectModels` uses the Postgres schema-introspector which maps `attr('date')` → `'TIMESTAMPTZ'`. The guard never matched — Date objects were still sent raw to DynamoDB.

**Fix:** Remove the `schema.columns[col] === 'date'` prefix. `value instanceof Date` alone is sufficient — the `date` transform guarantees real Date instances. No false positives.

**Before:** `(schema.columns[col] === 'date' && value instanceof Date)` — never true  
**After:** `(value instanceof Date)` — works correctly

Applied in both `_recordToItem` and `_persistUpdate`.

Closes #148

## Test plan

- [ ] Existing 10 Date serialization tests still pass (they do — the schema type in test fixtures was `'date'` which matched the old guard, but the fix works regardless)
- [ ] Full suite: 774 pass / 20 fail (all pre-existing)
- [ ] Downstream: ng-alerts can bump to this beta and remove cowboy workarounds