### PR TITLE
feat: add tablePrefix config to DynamoDB adapter (#150)

### DIFF
--- a/src/dynamodb/connection.ts
+++ b/src/dynamodb/connection.ts
@@ -8,6 +8,7 @@
 export interface DynamoDBConfig {
   region?: string;
   endpoint?: string;
+  tablePrefix?: string;
   [key: string]: unknown;
 }
 

--- a/src/dynamodb/dynamodb-db.ts
+++ b/src/dynamodb/dynamodb-db.ts
@@ -217,6 +217,10 @@ export default class DynamoDBDB {
     return this.client;
   }
 
+  private _resolveTableName(modelName: string): string {
+    return (this.dbConfig.tablePrefix ?? '') + sanitizeTableName(this.deps.getPluralName(modelName));
+  }
+
   /** Resolve Orm singleton — falls back to real import in production. */
   private async _getOrm(): Promise<OrmModule> {
     if (this.deps._importOrm) return this.deps._importOrm();
@@ -253,7 +257,7 @@ export default class DynamoDBDB {
     const rawClient = new DynamoDBClient(clientOptions);
 
     for (const [modelName, schema] of Object.entries(schemas)) {
-      const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+      const tableName = this._resolveTableName(modelName);
       const gsis = this._buildGsiDefinitions(modelName, schema);
 
       try {
@@ -338,7 +342,7 @@ export default class DynamoDBDB {
     const schema = schemas[modelName];
     if (!schema) return undefined;
 
-    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const tableName = this._resolveTableName(modelName);
     const { GetCommand } = await this.deps.loadDocClientCommands();
 
     const params = this.deps.buildGetItem(tableName, { id });
@@ -372,7 +376,7 @@ export default class DynamoDBDB {
     const schema = schemas[modelName];
     if (!schema) return [];
 
-    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const tableName = this._resolveTableName(modelName);
 
     try {
       let items: Record<string, unknown>[];
@@ -439,7 +443,7 @@ export default class DynamoDBDB {
       }
 
       const schema = schemas[modelName];
-      const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+      const tableName = this._resolveTableName(modelName);
 
       try {
         const items = await this._paginatedScan(tableName);
@@ -475,7 +479,7 @@ export default class DynamoDBDB {
     if (!record) return;
 
     const isPendingId = context.rawData?.__pendingSqlId === true;
-    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const tableName = this._resolveTableName(modelName);
 
     // For models with a pending ID, generate a unique replacement ID
     let finalId: unknown = record.id;
@@ -513,7 +517,7 @@ export default class DynamoDBDB {
     const record = context.record;
     if (!record) return;
 
-    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const tableName = this._resolveTableName(modelName);
     const id = record.id;
     const oldState = context.oldState || {};
     const currentData = record.__data;
@@ -558,7 +562,7 @@ export default class DynamoDBDB {
     const id = context.recordId;
     if (id == null) return;
 
-    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const tableName = this._resolveTableName(modelName);
     const { DeleteCommand } = await this.deps.loadDocClientCommands();
     const params = this.deps.buildDeleteItem(tableName, { id });
     await this.requireClient().send(new DeleteCommand(params));
@@ -620,7 +624,7 @@ export default class DynamoDBDB {
     const schemas = this.deps.introspectModels();
 
     for (const [modelName, schema] of Object.entries(schemas)) {
-      const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+      const tableName = this._resolveTableName(modelName);
       const modelGsis = new Map<string, string>();
 
       for (const fkCol of Object.keys(schema.foreignKeys)) {
@@ -682,7 +686,7 @@ export default class DynamoDBDB {
   }
 
   private _buildGsiDefinitions(modelName: string, schema: ModelSchema): unknown[] {
-    const tableName = sanitizeTableName(this.deps.getPluralName(modelName));
+    const tableName = this._resolveTableName(modelName);
     const gsis: unknown[] = [];
 
     for (const fkCol of Object.keys(schema.foreignKeys)) {

--- a/src/types/orm-types.ts
+++ b/src/types/orm-types.ts
@@ -51,6 +51,7 @@ export interface OrmRestServerConfig {
 export interface OrmDynamoDBConfig {
   region?: string;
   endpoint?: string;
+  tablePrefix?: string;
   [key: string]: unknown;
 }
 

--- a/test/unit/dynamodb/dynamodb-db-test.ts
+++ b/test/unit/dynamodb/dynamodb-db-test.ts
@@ -748,3 +748,273 @@ module('[Unit] DynamoDBDB._evictIfNotMemory', function(hooks) {
     assert.ok(modelStore.has(1), 'record untouched without resolver');
   });
 });
+
+module('[Unit] DynamoDBDB — table prefix', function(hooks) {
+  hooks.beforeEach(resetInstance);
+  hooks.afterEach(() => { resetInstance(); sinon.restore(); });
+
+  test('prefixed table name in persist (create)', async function(assert) {
+    const recordId = 'r1';
+    const record = { id: recordId, __data: { id: recordId, name: 'Alice' }, __relationships: {} };
+
+    const deps = createMockDeps({
+      config: {
+        rootPath: '/app',
+        orm: { dynamodb: { region: 'us-east-1', tablePrefix: 'staging-' } }
+      } as typeof deps.config,
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+      store: {
+        get: sinon.stub().returns(record),
+        _memoryResolver: null,
+      } as unknown as typeof deps.store,
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({});
+
+    await db.persist('create', 'user', { rawData: {} }, { data: { id: recordId } });
+
+    assert.ok(deps.buildPutItem.calledOnce, 'buildPutItem called');
+    assert.strictEqual(deps.buildPutItem.firstCall.args[0], 'staging-users', 'table name prefixed');
+  });
+
+  test('prefixed table name in persist (update)', async function(assert) {
+    const record = {
+      id: 'r1',
+      __data: { id: 'r1', name: 'Alice Updated' },
+      __relationships: {},
+    };
+
+    const deps = createMockDeps({
+      config: {
+        rootPath: '/app',
+        orm: { dynamodb: { region: 'us-east-1', tablePrefix: 'staging-' } }
+      } as typeof deps.config,
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({});
+
+    await db.persist('update', 'user', {
+      record: record as unknown as import('../../../src/types/orm-types.js').OrmRecord,
+      oldState: { name: 'Alice' },
+    }, {});
+
+    assert.ok(deps.buildUpdateItem.calledOnce, 'buildUpdateItem called');
+    assert.strictEqual(deps.buildUpdateItem.firstCall.args[0], 'staging-users', 'table name prefixed');
+  });
+
+  test('prefixed table name in persist (delete)', async function(assert) {
+    const deps = createMockDeps({
+      config: {
+        rootPath: '/app',
+        orm: { dynamodb: { region: 'us-east-1', tablePrefix: 'staging-' } }
+      } as typeof deps.config,
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: {}, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({});
+
+    await db.persist('delete', 'user', { recordId: 'r1' }, {});
+
+    assert.ok(deps.buildDeleteItem.calledOnce, 'buildDeleteItem called');
+    assert.strictEqual(deps.buildDeleteItem.firstCall.args[0], 'staging-users', 'table name prefixed');
+  });
+
+  test('prefixed table name in findRecord', async function(assert) {
+    const deps = createMockDeps({
+      config: {
+        rootPath: '/app',
+        orm: { dynamodb: { region: 'us-east-1', tablePrefix: 'staging-' } }
+      } as typeof deps.config,
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({ Item: { id: 'r1', name: 'Alice' } });
+
+    await db.findRecord('user', 'r1');
+
+    assert.ok(deps.buildGetItem.calledOnce, 'buildGetItem called');
+    assert.strictEqual(deps.buildGetItem.firstCall.args[0], 'staging-users', 'table name prefixed');
+  });
+
+  test('prefixed table name in findAll (scan)', async function(assert) {
+    const deps = createMockDeps({
+      config: {
+        rootPath: '/app',
+        orm: { dynamodb: { region: 'us-east-1', tablePrefix: 'staging-' } }
+      } as typeof deps.config,
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({ Items: [{ id: '1', name: 'A' }], LastEvaluatedKey: undefined });
+
+    await db.findAll('user');
+
+    assert.ok(deps.buildScan.calledOnce, 'buildScan called');
+    assert.strictEqual(deps.buildScan.firstCall.args[0], 'staging-users', 'table name prefixed');
+  });
+
+  test('prefixed table name in findAll (query via GSI)', async function(assert) {
+    const deps = createMockDeps({
+      config: {
+        rootPath: '/app',
+        orm: { dynamodb: { region: 'us-east-1', tablePrefix: 'staging-' } }
+      } as typeof deps.config,
+      introspectModels: sinon.stub().returns({
+        'comment': {
+          table: 'comments',
+          columns: { body: 'S' },
+          foreignKeys: { post_id: { references: 'posts', column: 'id' } },
+          idType: 'string',
+        }
+      }),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    // Re-init to build GSI registry with the prefixed table name
+    await db.init();
+
+    // Replace the client with our mock after init
+    db.client = mockClient;
+    mockClient.send.resolves({ Items: [{ id: 'c1', body: 'Hello', post_id: 'p1' }], LastEvaluatedKey: undefined });
+
+    await db.findAll('comment', { post_id: 'p1' });
+
+    assert.ok(deps.buildQuery.calledOnce, 'buildQuery called');
+    assert.strictEqual(deps.buildQuery.firstCall.args[0], 'staging-comments', 'table name prefixed');
+    assert.strictEqual(deps.buildQuery.firstCall.args[1], 'staging-comments-post_id-index', 'GSI name prefixed');
+  });
+
+  test('prefixed table name in loadMemoryRecords', async function(assert) {
+    const deps = createMockDeps({
+      config: {
+        rootPath: '/app',
+        orm: { dynamodb: { region: 'us-east-1', tablePrefix: 'staging-' } }
+      } as typeof deps.config,
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getTopologicalOrder: sinon.stub().returns(['user']),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({ Items: [{ id: 'u1', name: 'Alice' }], LastEvaluatedKey: undefined });
+
+    await db.loadMemoryRecords();
+
+    assert.ok(deps.buildScan.calledOnce, 'buildScan called');
+    assert.strictEqual(deps.buildScan.firstCall.args[0], 'staging-users', 'table name prefixed');
+  });
+
+  test('no prefix when tablePrefix omitted', async function(assert) {
+    const deps = createMockDeps({
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    mockClient.send.resolves({ Item: { id: 'r1', name: 'Alice' } });
+
+    await db.findRecord('user', 'r1');
+
+    assert.ok(deps.buildGetItem.calledOnce, 'buildGetItem called');
+    assert.strictEqual(deps.buildGetItem.firstCall.args[0], 'users', 'table name without prefix');
+  });
+
+  test('prefixed table name in startup', async function(assert) {
+    const rawClientSend = sinon.stub();
+    // Call 0: DescribeTable → ResourceNotFoundException (table missing)
+    // Call 1: CreateTable → resolves
+    // Call 2: _waitForTableActive polls DescribeTable → ACTIVE
+    rawClientSend.onCall(0).rejects(Object.assign(new Error('No such table'), { name: 'ResourceNotFoundException' }));
+    rawClientSend.onCall(1).resolves({});
+    rawClientSend.onCall(2).resolves({ Table: { TableStatus: 'ACTIVE' } });
+
+    const DescribeTableCommand = makeCommandStub('DescribeTableCommand');
+    const CreateTableCommand = makeCommandStub('CreateTableCommand');
+    const UpdateTableCommand = makeCommandStub('UpdateTableCommand');
+
+    const deps = createMockDeps({
+      config: {
+        rootPath: '/app',
+        orm: { dynamodb: { region: 'us-east-1', tablePrefix: 'staging-' } }
+      } as typeof deps.config,
+      introspectModels: sinon.stub().returns({
+        'user': { table: 'users', columns: { name: 'S' }, foreignKeys: {}, idType: 'string' }
+      }),
+      getPluralName: sinon.stub().returns('users'),
+      loadTableCommands: sinon.stub().resolves({
+        DynamoDBClient: function(this: { send: sinon.SinonStub }) { this.send = rawClientSend; },
+        DescribeTableCommand,
+        CreateTableCommand,
+        UpdateTableCommand,
+      }),
+    });
+
+    const { db } = buildDb(deps);
+    await db.startup();
+
+    // DescribeTable (call 0) should receive prefixed table name
+    const describeParams = (rawClientSend.firstCall.args[0] as { params: { TableName: string } }).params;
+    assert.strictEqual(describeParams.TableName, 'staging-users', 'DescribeTableCommand receives prefixed table name');
+
+    // CreateTable (call 1) should receive prefixed table name
+    const createParams = (rawClientSend.secondCall.args[0] as { params: { TableName: string } }).params;
+    assert.strictEqual(createParams.TableName, 'staging-users', 'CreateTableCommand receives prefixed table name');
+  });
+
+  test('prefixed GSI names in registry', async function(assert) {
+    const deps = createMockDeps({
+      config: {
+        rootPath: '/app',
+        orm: { dynamodb: { region: 'us-east-1', tablePrefix: 'staging-' } }
+      } as typeof deps.config,
+      introspectModels: sinon.stub().returns({
+        'comment': {
+          table: 'comments',
+          columns: { body: 'S' },
+          foreignKeys: { post_id: { references: 'posts', column: 'id' } },
+          idType: 'string',
+        }
+      }),
+      getPluralName: sinon.stub().callsFake((name: string) => `${name}s`),
+    });
+
+    const { db, mockClient } = buildDb(deps);
+    // init() triggers _buildGsiRegistry
+    await db.init();
+
+    // Replace the client with our mock after init
+    db.client = mockClient;
+    mockClient.send.resolves({ Items: [{ id: 'c1', body: 'Hi', post_id: 'p1' }], LastEvaluatedKey: undefined });
+
+    await db.findAll('comment', { post_id: 'p1' });
+
+    assert.ok(deps.buildQuery.calledOnce, 'buildQuery called');
+    assert.strictEqual(deps.buildQuery.firstCall.args[1], 'staging-comments-post_id-index', 'GSI name includes prefix');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds optional `tablePrefix` config to `DynamoDBConfig` for staging/production table isolation
- Introduces `_resolveTableName()` private helper that prepends the prefix to all 9 table name resolution points
- GSI names naturally inherit the prefix since they derive from the resolved table name
- 10 new unit tests covering all CRUD operations, startup, GSI registry, and backward compatibility

## Closes

Closes #150

## Test plan

- [x] All 10 new table prefix unit tests pass
- [x] All existing unit tests pass (784 pass, 20 pre-existing integration failures)
- [x] Backward compat: omitting `tablePrefix` preserves current behavior (explicit test)
- [ ] Downstream validation: ng-alerts staging with `tablePrefix: 'nextgoal-staging-'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)