### PR TITLE
fix: strip undefined/null values from buildScan/buildQuery conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "stonyx-async",
     "stonyx-module"
   ],
-  "version": "0.3.2-beta.83",
+  "version": "0.3.2-beta.84",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/src/dynamodb/operation-builder.ts
+++ b/src/dynamodb/operation-builder.ts
@@ -131,21 +131,27 @@ export function buildScan(
   if (exclusiveStartKey) params.ExclusiveStartKey = exclusiveStartKey;
 
   if (conditions && Object.keys(conditions).length > 0) {
-    const names: Record<string, string> = {};
-    const values: Record<string, unknown> = {};
-    const clauses: string[] = [];
+    const validEntries = Object.entries(conditions).filter(
+      ([, val]) => val !== undefined && val !== null,
+    );
 
-    for (const [attr, val] of Object.entries(conditions)) {
-      const nameAlias = `#${attr}`;
-      const valAlias = `:${attr}`;
-      names[nameAlias] = attr;
-      values[valAlias] = val;
-      clauses.push(`${nameAlias} = ${valAlias}`);
+    if (validEntries.length > 0) {
+      const names: Record<string, string> = {};
+      const values: Record<string, unknown> = {};
+      const clauses: string[] = [];
+
+      for (const [attr, val] of validEntries) {
+        const nameAlias = `#${attr}`;
+        const valAlias = `:${attr}`;
+        names[nameAlias] = attr;
+        values[valAlias] = val;
+        clauses.push(`${nameAlias} = ${valAlias}`);
+      }
+
+      params.FilterExpression = clauses.join(' AND ');
+      params.ExpressionAttributeNames = names;
+      params.ExpressionAttributeValues = values;
     }
-
-    params.FilterExpression = clauses.join(' AND ');
-    params.ExpressionAttributeNames = names;
-    params.ExpressionAttributeValues = values;
   }
 
   return params;
@@ -162,11 +168,19 @@ export function buildQuery(
   keyConditions: Record<string, unknown>,
   exclusiveStartKey?: Record<string, unknown>,
 ): QueryParams {
+  const validEntries = Object.entries(keyConditions).filter(
+    ([, val]) => val !== undefined && val !== null,
+  );
+
+  if (validEntries.length === 0) {
+    throw new Error('buildQuery: all keyCondition values are undefined/null');
+  }
+
   const names: Record<string, string> = {};
   const values: Record<string, unknown> = {};
   const clauses: string[] = [];
 
-  for (const [attr, val] of Object.entries(keyConditions)) {
+  for (const [attr, val] of validEntries) {
     const nameAlias = `#${attr}`;
     const valAlias = `:${attr}`;
     names[nameAlias] = attr;

--- a/test/unit/dynamodb/operation-builder-test.ts
+++ b/test/unit/dynamodb/operation-builder-test.ts
@@ -114,6 +114,35 @@ module('[Unit] DynamoDB operation-builder — buildScan', function() {
   });
 });
 
+module('[Unit] DynamoDB operation-builder — buildScan (undefined/null stripping)', function() {
+  test('scan with all-undefined conditions behaves like unfiltered scan', function(assert) {
+    const params = buildScan('alerts', { email: undefined });
+
+    assert.strictEqual(params.TableName, 'alerts');
+    assert.strictEqual(params.FilterExpression, undefined, 'no FilterExpression');
+    assert.strictEqual(params.ExpressionAttributeNames, undefined, 'no ExpressionAttributeNames');
+    assert.strictEqual(params.ExpressionAttributeValues, undefined, 'no ExpressionAttributeValues');
+  });
+
+  test('scan strips undefined values from mixed conditions', function(assert) {
+    const params = buildScan('alerts', { status: 'active', email: undefined });
+
+    assert.ok(params.FilterExpression, 'FilterExpression set');
+    assert.ok(params.FilterExpression!.includes('#status = :status'), 'status in expression');
+    assert.notOk(params.FilterExpression!.includes('email'), 'email not in expression');
+    assert.deepEqual(params.ExpressionAttributeNames, { '#status': 'status' });
+    assert.deepEqual(params.ExpressionAttributeValues, { ':status': 'active' });
+  });
+
+  test('scan strips null values from conditions', function(assert) {
+    const params = buildScan('alerts', { status: null });
+
+    assert.strictEqual(params.FilterExpression, undefined, 'no FilterExpression');
+    assert.strictEqual(params.ExpressionAttributeNames, undefined, 'no ExpressionAttributeNames');
+    assert.strictEqual(params.ExpressionAttributeValues, undefined, 'no ExpressionAttributeValues');
+  });
+});
+
 module('[Unit] DynamoDB operation-builder — buildQuery', function() {
   test('builds query for single GSI key condition', function(assert) {
     const params = buildQuery('sessions', 'user-index', { userId: 'u1' });
@@ -138,5 +167,24 @@ module('[Unit] DynamoDB operation-builder — buildQuery', function() {
     const params = buildQuery('sessions', 'user-index', { userId: 'u1' }, startKey);
 
     assert.deepEqual(params.ExclusiveStartKey, startKey);
+  });
+});
+
+module('[Unit] DynamoDB operation-builder — buildQuery (undefined/null stripping)', function() {
+  test('query throws when all keyCondition values are undefined/null', function(assert) {
+    assert.throws(
+      () => buildQuery('sessions', 'user-index', { userId: undefined }),
+      /buildQuery: all keyCondition values are undefined\/null/,
+      'throws descriptive error',
+    );
+  });
+
+  test('query strips undefined values from mixed keyConditions', function(assert) {
+    const params = buildQuery('orders', 'user-status-index', { userId: 'u1', status: undefined });
+
+    assert.ok(params.KeyConditionExpression.includes('#userId = :userId'), 'userId in expression');
+    assert.notOk(params.KeyConditionExpression.includes('status'), 'status not in expression');
+    assert.deepEqual(params.ExpressionAttributeNames, { '#userId': 'userId' });
+    assert.deepEqual(params.ExpressionAttributeValues, { ':userId': 'u1' });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #152.

- `buildScan()` now filters out `undefined`/`null` condition values before building `FilterExpression`. If all values are nullish, returns an unfiltered scan (no `FilterExpression`/`ExpressionAttributeValues`).
- `buildQuery()` applies the same filtering. If all key conditions are nullish after filtering, throws a clear error (`buildQuery: all keyCondition values are undefined/null`) since GSI queries require at least one valid key condition.

## Test plan

- [x] 5 new unit tests covering all edge cases (all-undefined scan, mixed conditions scan, null conditions scan, all-undefined query throws, mixed conditions query)
- [x] All 809 unit tests pass (0 failures)
- [x] Pre-existing integration test failures are unrelated (DynamoDB localhost)

## Blocked downstream

nextgoal-alerts#486 — staging auth flow passes `{ email: undefined }` to `findAll` which hits `buildScan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)