### PR TITLE
fix: move @stonyx/utils from devDependencies to dependencies (#162)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@stonyx/cron": "0.2.1-beta.70",
     "@stonyx/events": "0.1.1-beta.51",
+    "@stonyx/utils": "0.2.3-beta.25",
     "stonyx": "0.2.3-beta.68"
   },
   "peerDependencies": {
@@ -105,7 +106,6 @@
   },
   "devDependencies": {
     "@stonyx/rest-server": "0.2.1-beta.71",
-    "@stonyx/utils": "0.2.3-beta.25",
     "@types/node": "^25.6.0",
     "mysql2": "^3.20.0",
     "pg": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@stonyx/events':
         specifier: 0.1.1-beta.51
         version: 0.1.1-beta.51
+      '@stonyx/utils':
+        specifier: 0.2.3-beta.23
+        version: 0.2.3-beta.23
       stonyx:
         specifier: 0.2.3-beta.61
         version: 0.2.3-beta.61
@@ -32,9 +35,6 @@ importers:
       '@stonyx/rest-server':
         specifier: 0.2.1-beta.71
         version: 0.2.1-beta.71
-      '@stonyx/utils':
-        specifier: 0.2.3-beta.23
-        version: 0.2.3-beta.23
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0


### PR DESCRIPTION
## Summary

- Moves `@stonyx/utils` from `devDependencies` to `dependencies` in package.json
- `@stonyx/utils` is imported in 15+ production source files (record.ts, orm-request.ts, main.ts, etc.)
- pnpm strict mode in ECS containers can't resolve the transitive dependency through `stonyx` core

Fixes #162. Unblocks SynamicD/manager ECS deployment.

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` — 809/809 pass
- [x] `@stonyx/utils` resolves as a direct dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)