### PR TITLE
fix: await delete persist in the request path

### DIFF
--- a/src/orm-request.ts
+++ b/src/orm-request.ts
@@ -376,7 +376,7 @@ export default class OrmRequest extends Request {
     };
 
     const deleteHandler: HandlerFn = ({ params }) => {
-      store.remove(model, getId(params));
+      store.remove(model, getId(params), { _skipAutoPersist: true });
       return 204;
     };
 
@@ -448,9 +448,9 @@ export default class OrmRequest extends Request {
         context.record = store.get(this.model, getId(request.params));
       }
 
-      // Persist to SQL database for create/update (delete is handled by store.remove auto-persist)
+      // Persist to SQL database for all write operations (create/update/delete)
       const sqlDb = Orm.instance.sqlDb;
-      if (sqlDb && (operation === 'create' || operation === 'update')) {
+      if (sqlDb && WRITE_OPERATIONS.has(operation)) {
         await sqlDb.persist(operation, this.model, context, response);
       }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -170,14 +170,15 @@ export default class Store {
     this.data.set(key, value);
   }
 
-  remove(key: string, id?: number | string): void {
+  remove(key: string, id?: number | string, options?: { _skipAutoPersist?: boolean }): void {
     // Guard: read-only views cannot have records removed
     if (Orm.instance?.isView?.(key)) {
       throw new Error(`Cannot remove records from read-only view '${key}'`);
     }
 
-    // Auto-persist delete to SQL
-    if (id && Orm.instance?.sqlDb) {
+    // Auto-persist delete to SQL (fire-and-forget) — skipped when the
+    // request path handles persist itself to avoid double-delete.
+    if (id && Orm.instance?.sqlDb && !options?._skipAutoPersist) {
       Orm.instance.sqlDb.persist('delete', key, { recordId: id }, {}).catch((err: unknown) => {
         Orm.instance.emitPersistError({
           operation: 'delete',

--- a/test/unit/delete-persist-test.ts
+++ b/test/unit/delete-persist-test.ts
@@ -1,0 +1,180 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import Orm, { createRecord, store } from '@stonyx/orm';
+import OrmRequest from '../../src/orm-request.js';
+
+const { module, test } = QUnit;
+
+module('[Unit] DELETE persist — awaited in request path (#157)', function(hooks) {
+  let originalSqlDb;
+  let originalInitialized;
+
+  hooks.beforeEach(function() {
+    originalSqlDb = Orm.instance?.sqlDb;
+    originalInitialized = Orm.initialized;
+  });
+
+  hooks.afterEach(function() {
+    if (Orm.instance) Orm.instance.sqlDb = originalSqlDb;
+    Orm.initialized = originalInitialized;
+    store.get('owner')?.clear();
+    sinon.restore();
+  });
+
+  test('sqlDb.persist is awaited for delete before response returns', async function(assert) {
+    let persistResolved = false;
+    const persistStub = sinon.stub().callsFake(() => {
+      return new Promise((resolve) => {
+        // Simulate async SQL work — the handler must wait for this
+        setTimeout(() => {
+          persistResolved = true;
+          resolve();
+        }, 10);
+      });
+    });
+
+    Orm.initialized = true;
+    Orm.instance.sqlDb = { persist: persistStub };
+
+    // Pre-populate a record in the store
+    createRecord('owner', { id: 'del-1', gender: 'male', age: 30 }, { serialize: false, _skipAutoPersist: true });
+
+    const ormRequest = new OrmRequest({ model: 'owner', access: () => true });
+    const deleteHandler = ormRequest.handlers.delete['/:id'];
+
+    const request = {
+      protocol: 'http',
+      method: 'DELETE',
+      params: { id: 'del-1' },
+      body: undefined,
+      query: {},
+      get: () => 'localhost',
+    };
+
+    const response = await deleteHandler(request, {});
+
+    // Key assertion: persist must have completed BEFORE the handler returned
+    assert.true(persistResolved, 'sqlDb.persist resolved before DELETE response returned');
+    assert.strictEqual(response, 204, 'handler returns 204');
+    assert.ok(persistStub.calledOnce, 'sqlDb.persist was called exactly once (no double-persist)');
+    assert.strictEqual(persistStub.firstCall.args[0], 'delete', 'persist called with delete operation');
+  });
+
+  test('context.recordId is set when persist is called for delete', async function(assert) {
+    let capturedContext = null;
+    const persistStub = sinon.stub().callsFake((_op, _model, context) => {
+      capturedContext = { recordId: context.recordId, oldState: context.oldState };
+      return Promise.resolve();
+    });
+
+    Orm.initialized = true;
+    Orm.instance.sqlDb = { persist: persistStub };
+
+    createRecord('owner', { id: 'del-2', gender: 'female', age: 25 }, { serialize: false, _skipAutoPersist: true });
+
+    const ormRequest = new OrmRequest({ model: 'owner', access: () => true });
+    const deleteHandler = ormRequest.handlers.delete['/:id'];
+
+    const request = {
+      protocol: 'http',
+      method: 'DELETE',
+      params: { id: 'del-2' },
+      body: undefined,
+      query: {},
+      get: () => 'localhost',
+    };
+
+    await deleteHandler(request, {});
+
+    assert.ok(capturedContext, 'context was captured');
+    assert.strictEqual(capturedContext.recordId, 'del-2', 'context.recordId is set correctly');
+    assert.ok(capturedContext.oldState, 'context.oldState is captured before delete');
+  });
+
+  test('persist errors propagate (not silently caught) in request path', async function(assert) {
+    const persistError = new Error('SQL connection lost');
+    const persistStub = sinon.stub().rejects(persistError);
+
+    Orm.initialized = true;
+    Orm.instance.sqlDb = { persist: persistStub };
+
+    createRecord('owner', { id: 'del-3', gender: 'male', age: 40 }, { serialize: false, _skipAutoPersist: true });
+
+    const ormRequest = new OrmRequest({ model: 'owner', access: () => true });
+    const deleteHandler = ormRequest.handlers.delete['/:id'];
+
+    const request = {
+      protocol: 'http',
+      method: 'DELETE',
+      params: { id: 'del-3' },
+      body: undefined,
+      query: {},
+      get: () => 'localhost',
+    };
+
+    try {
+      await deleteHandler(request, {});
+      assert.ok(false, 'should have thrown');
+    } catch (err) {
+      assert.strictEqual(err, persistError, 'persist error propagates to caller');
+    }
+  });
+
+  test('store.remove without _skipAutoPersist still fires auto-persist', function(assert) {
+    const persistStub = sinon.stub().resolves();
+
+    Orm.initialized = true;
+    Orm.instance.sqlDb = { persist: persistStub };
+
+    createRecord('owner', { id: 'del-4', gender: 'male', age: 50 }, { serialize: false, _skipAutoPersist: true });
+
+    // Call remove without _skipAutoPersist (simulates hook or programmatic usage)
+    store.remove('owner', 'del-4');
+
+    assert.ok(persistStub.calledOnce, 'auto-persist fires for non-request-path remove');
+    assert.strictEqual(persistStub.firstCall.args[0], 'delete', 'auto-persist uses delete operation');
+  });
+
+  test('store.remove with _skipAutoPersist suppresses auto-persist', function(assert) {
+    const persistStub = sinon.stub().resolves();
+
+    Orm.initialized = true;
+    Orm.instance.sqlDb = { persist: persistStub };
+
+    createRecord('owner', { id: 'del-5', gender: 'female', age: 35 }, { serialize: false, _skipAutoPersist: true });
+
+    // Call remove with _skipAutoPersist (simulates request-path usage)
+    store.remove('owner', 'del-5', { _skipAutoPersist: true });
+
+    assert.notOk(persistStub.called, 'auto-persist is suppressed when _skipAutoPersist is set');
+  });
+
+  test('no double-persist — delete persists exactly once via request path', async function(assert) {
+    const persistStub = sinon.stub().resolves();
+
+    Orm.initialized = true;
+    Orm.instance.sqlDb = { persist: persistStub };
+
+    createRecord('owner', { id: 'del-6', gender: 'male', age: 60 }, { serialize: false, _skipAutoPersist: true });
+
+    const ormRequest = new OrmRequest({ model: 'owner', access: () => true });
+    const deleteHandler = ormRequest.handlers.delete['/:id'];
+
+    const request = {
+      protocol: 'http',
+      method: 'DELETE',
+      params: { id: 'del-6' },
+      body: undefined,
+      query: {},
+      get: () => 'localhost',
+    };
+
+    await deleteHandler(request, {});
+
+    // Must be exactly one persist call — not zero (fire-and-forget removed) and not two (no double-persist)
+    assert.strictEqual(persistStub.callCount, 1, 'persist called exactly once');
+    assert.strictEqual(persistStub.firstCall.args[0], 'delete', 'the single persist is a delete');
+    assert.strictEqual(persistStub.firstCall.args[1], 'owner', 'persist targets the correct model');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #157.

- DELETE operations were persisted to SQL via fire-and-forget in `store.remove()`, meaning HTTP 204 could return before the SQL DELETE executed. If the process crashed in that window, the write was lost.
- Moved delete persist into the awaited path in `orm-request.ts` (alongside create/update) by using the existing `WRITE_OPERATIONS` set in the persist condition.
- Added `_skipAutoPersist` option to `store.remove()` so the request path can suppress the fire-and-forget persist, preventing double-delete. Non-request-path callers (hooks, programmatic usage) still get auto-persist.

## Changes

**`src/orm-request.ts`**
- `deleteHandler` passes `{ _skipAutoPersist: true }` to `store.remove()`
- Persist condition changed from `operation === 'create' || operation === 'update'` to `WRITE_OPERATIONS.has(operation)` (which already included `'delete'`)

**`src/store.ts`**
- `remove()` accepts optional `options?: { _skipAutoPersist?: boolean }` parameter
- When `_skipAutoPersist` is set, the fire-and-forget persist is suppressed

**`test/unit/delete-persist-test.ts`** — 6 new tests:
1. `sqlDb.persist` is awaited before response returns
2. `context.recordId` is set when persist is called
3. Persist errors propagate (not silently caught)
4. Non-request-path `store.remove()` still fires auto-persist
5. `_skipAutoPersist` suppresses auto-persist
6. No double-persist — exactly one DELETE SQL per request

## Test plan

- [x] All 818 tests pass (812 existing + 6 new)
- [x] New tests would have FAILED before the fix (persist was fire-and-forget, not awaited)
- [x] No double-persist verified by asserting `persistStub.callCount === 1`
- [x] Non-request-path `store.remove()` callers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)