### PR TITLE
fix: guard toJSON/format against clean()ed records in relationships

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -87,12 +87,15 @@ export default class Record {
 
     for (const [key, childRecord] of Object.entries(this.__relationships)) {
       if (Array.isArray(childRecord)) {
+        // Filter out cleaned records (those with no __model)
+        const live = childRecord.filter((r: Record) => r?.__model);
+
         // Deduplicate by record ID — keep last occurrence (latest data wins)
         const seen = new Set<unknown>();
         const unique: Record[] = [];
 
-        for (let i = childRecord.length - 1; i >= 0; i--) {
-          const r = childRecord[i] as Record;
+        for (let i = live.length - 1; i >= 0; i--) {
+          const r = live[i] as Record;
           if (!seen.has(r.id)) {
             seen.add(r.id);
             unique.push(r);
@@ -102,7 +105,7 @@ export default class Record {
         unique.reverse();
         records[key] = unique.map((r: Record) => r.serialize());
       } else {
-        records[key] = (childRecord as Record)?.serialize() ?? null;
+        records[key] = (childRecord as Record)?.__model ? (childRecord as Record).serialize() : null;
       }
     }
 
@@ -136,8 +139,8 @@ export default class Record {
       if (fields && !fields.has(key)) continue;
 
       const relationshipData = Array.isArray(childRecord)
-        ? childRecord.map((r: Record) => ({ type: r.__model.__name, id: r.id }))
-        : childRecord ? { type: (childRecord as Record).__model.__name, id: (childRecord as Record).id } : null;
+        ? childRecord.filter((r: Record) => r?.__model).map((r: Record) => ({ type: r.__model.__name, id: r.id }))
+        : (childRecord && (childRecord as Record).__model) ? { type: (childRecord as Record).__model.__name, id: (childRecord as Record).id } : null;
 
       // Dasherize the key for URL paths (e.g., accessLinks -> access-links)
       const dasherizedKey = camelCaseToKebabCase(key);

--- a/test/unit/record-tojson-cleaned-test.ts
+++ b/test/unit/record-tojson-cleaned-test.ts
@@ -1,0 +1,139 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import { createRecord, store, relationships } from '@stonyx/orm';
+
+const { module, test } = QUnit;
+
+module('[Unit] Record | toJSON/format with cleaned records (#170)', function(hooks) {
+  const clearStores = function() {
+    const models = ['owner', 'animal', 'trait', 'category', 'phone-number'];
+    for (const model of models) {
+      const modelStore = store.get(model);
+      if (modelStore) modelStore.clear();
+    }
+
+    relationships.get('hasMany')?.clear();
+    relationships.get('belongsTo')?.clear();
+    relationships.get('pending')?.clear();
+    relationships.get('pendingBelongsTo')?.clear();
+  };
+
+  hooks.beforeEach(clearStores);
+  hooks.afterEach(clearStores);
+
+  module('toJSON with cleaned records', function() {
+    test('toJSON does not throw when hasMany array contains a cleaned record', function(assert) {
+      const owner = createRecord('owner', { id: 'owner-clean-1', gender: 'male', age: 30 }, { serialize: false });
+      const animal = createRecord('animal', { id: 1, type: 'dog', age: 3, size: 'large', owner: 'owner-clean-1' }, { serialize: false });
+
+      // Verify pet is wired before cleaning
+      assert.strictEqual(owner.pets.length, 1, 'pet is wired before clean');
+
+      // Simulate a cleaned record (all properties deleted)
+      animal.clean();
+
+      // Should not throw
+      const json = owner.toJSON();
+      assert.ok(json, 'toJSON returns without throwing');
+    });
+
+    test('toJSON output excludes the cleaned record from relationship data array', function(assert) {
+      const owner = createRecord('owner', { id: 'owner-clean-2', gender: 'female', age: 25 }, { serialize: false });
+      createRecord('animal', { id: 2, type: 'cat', age: 2, size: 'small', owner: 'owner-clean-2' }, { serialize: false });
+      const animal2 = createRecord('animal', { id: 3, type: 'dog', age: 4, size: 'medium', owner: 'owner-clean-2' }, { serialize: false });
+
+      // Clean only one of the two animals
+      animal2.clean();
+
+      const json = owner.toJSON();
+      const petsData = json.relationships.pets.data;
+
+      assert.ok(Array.isArray(petsData), 'pets data is still an array');
+      assert.strictEqual(petsData.length, 1, 'cleaned record excluded from array');
+      assert.strictEqual(petsData[0].id, 2, 'remaining record has correct id');
+    });
+
+    test('toJSON does not throw when belongsTo slot contains a cleaned record', function(assert) {
+      const owner = createRecord('owner', { id: 'owner-clean-3', gender: 'male', age: 40 }, { serialize: false });
+      const animal = createRecord('animal', { id: 4, type: 'dog', age: 5, size: 'large', owner: 'owner-clean-3' }, { serialize: false });
+
+      // Verify belongsTo is wired
+      assert.strictEqual(animal.owner, owner, 'owner is wired before clean');
+
+      // Clean the owner record
+      owner.clean();
+
+      // Should not throw
+      const json = animal.toJSON();
+      assert.ok(json, 'toJSON returns without throwing');
+    });
+
+    test('toJSON output shows null for cleaned belongsTo relationship data', function(assert) {
+      const owner = createRecord('owner', { id: 'owner-clean-4', gender: 'female', age: 35 }, { serialize: false });
+      const animal = createRecord('animal', { id: 5, type: 'cat', age: 1, size: 'small', owner: 'owner-clean-4' }, { serialize: false });
+
+      // Clean the owner
+      owner.clean();
+
+      const json = animal.toJSON();
+      assert.strictEqual(json.relationships.owner.data, null, 'cleaned belongsTo shows null');
+    });
+  });
+
+  module('format with cleaned records', function() {
+    test('format does not throw when hasMany array contains a cleaned record', function(assert) {
+      const owner = createRecord('owner', { id: 'owner-clean-5', gender: 'male', age: 30 }, { serialize: false });
+      const animal = createRecord('animal', { id: 6, type: 'dog', age: 3, size: 'large', owner: 'owner-clean-5' }, { serialize: false });
+
+      // Verify pet is wired before cleaning
+      assert.strictEqual(owner.pets.length, 1, 'pet is wired before clean');
+
+      // Simulate a cleaned record
+      animal.clean();
+
+      // Should not throw
+      const formatted = owner.format();
+      assert.ok(formatted, 'format returns without throwing');
+    });
+
+    test('format output excludes cleaned record from serialized array', function(assert) {
+      const owner = createRecord('owner', { id: 'owner-clean-6', gender: 'female', age: 25 }, { serialize: false });
+      createRecord('animal', { id: 7, type: 'cat', age: 2, size: 'small', owner: 'owner-clean-6' }, { serialize: false });
+      const animal2 = createRecord('animal', { id: 8, type: 'dog', age: 4, size: 'medium', owner: 'owner-clean-6' }, { serialize: false });
+
+      // Clean only one
+      animal2.clean();
+
+      const formatted = owner.format();
+      assert.ok(Array.isArray(formatted.pets), 'pets is still an array');
+      assert.strictEqual(formatted.pets.length, 1, 'cleaned record excluded');
+      assert.strictEqual(formatted.pets[0].id, 7, 'remaining record has correct id');
+    });
+
+    test('format does not throw when belongsTo slot contains a cleaned record', function(assert) {
+      const owner = createRecord('owner', { id: 'owner-clean-7', gender: 'male', age: 40 }, { serialize: false });
+      const animal = createRecord('animal', { id: 9, type: 'dog', age: 5, size: 'large', owner: 'owner-clean-7' }, { serialize: false });
+
+      // Verify belongsTo is wired
+      assert.strictEqual(animal.owner, owner, 'owner is wired before clean');
+
+      // Clean the owner
+      owner.clean();
+
+      // Should not throw
+      const formatted = animal.format();
+      assert.ok(formatted, 'format returns without throwing');
+    });
+
+    test('format output shows null for cleaned belongsTo slot', function(assert) {
+      const owner = createRecord('owner', { id: 'owner-clean-8', gender: 'female', age: 35 }, { serialize: false });
+      const animal = createRecord('animal', { id: 10, type: 'cat', age: 1, size: 'small', owner: 'owner-clean-8' }, { serialize: false });
+
+      // Clean the owner
+      owner.clean();
+
+      const formatted = animal.format();
+      assert.strictEqual(formatted.owner, null, 'cleaned belongsTo shows null in format output');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #170

- Adds defensive guards in `toJSON()` and `format()` to filter out cleaned records from hasMany relationship arrays and treat cleaned belongsTo slots as `null`
- Prevents `TypeError: Cannot read properties of undefined (reading '__name')` when serializing records whose relationship targets have been unloaded via `clean()`
- 8 regression tests covering both methods × both relationship types (hasMany/belongsTo) × crash prevention + output correctness

## Root Cause

`store.unloadRecord()` calls `_removeFromHasManyArrays()` which only cleans the hasMany registry, not the parent record's `__relationships` object. Under concurrency or with legacy rows, a parent can still hold a direct reference to a now-cleaned child when `toJSON()` or `format()` runs.

## Approach

Guard at the serialization boundary rather than modifying store internals — this protects against all edge states (concurrency, legacy data, future bugs in unload paths) with minimal blast radius.

## Test Plan

- [x] 8 new unit tests in `test/unit/record-tojson-cleaned-test.ts`
- [x] All 839 tests pass (`pnpm test`)
- [x] No changes to store internals or `clean()` behavior

## Cross-Project Impact

Resolves fleet-wide crash in smart-lock prod (hundreds of occurrences/day since 2026-05-14).