### PR TITLE
fix: add autoMigrate config to bypass interactive prompts in headless containers (#172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ export default {
       connectionLimit: parseInt(MYSQL_CONNECTION_LIMIT ?? '10'),
       migrationsDir: MYSQL_MIGRATIONS_DIR ?? 'migrations',
       migrationsTable: '__migrations',
+      autoMigrate: AUTO_MIGRATE === 'true' ? true : AUTO_MIGRATE === 'false' ? false : undefined,
     } : undefined,
     dynamodb: DYNAMODB_REGION ? {
       region: DYNAMODB_REGION,

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -280,6 +280,7 @@ Located in `config/environment.js`. All values overridable via environment varia
 | `MYSQL_DATABASE` | `'stonyx'` | MySQL database name |
 | `MYSQL_CONNECTION_LIMIT` | `10` | Connection pool size |
 | `MYSQL_MIGRATIONS_DIR` | `'migrations'` | Migration files directory |
+| `AUTO_MIGRATE` | undefined | `'true'` auto-applies migrations, `'false'` skips with warning, unset prompts interactively (requires TTY) |
 
 ## Development Guide
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "pnpm": {
     "overrides": {
       "stonyx": "0.2.3-beta.61",
-      "@stonyx/utils": "0.2.3-beta.23",
+      "@stonyx/utils": "0.2.3-beta.25",
       "@stonyx/logs": "1.0.1-beta.16"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   stonyx: 0.2.3-beta.61
-  '@stonyx/utils': 0.2.3-beta.23
+  '@stonyx/utils': 0.2.3-beta.25
   '@stonyx/logs': 1.0.1-beta.16
 
 importers:
@@ -26,8 +26,8 @@ importers:
         specifier: 0.1.1-beta.51
         version: 0.1.1-beta.51
       '@stonyx/utils':
-        specifier: 0.2.3-beta.23
-        version: 0.2.3-beta.23
+        specifier: 0.2.3-beta.25
+        version: 0.2.3-beta.25
       stonyx:
         specifier: 0.2.3-beta.61
         version: 0.2.3-beta.61
@@ -420,8 +420,8 @@ packages:
   '@stonyx/rest-server@0.2.1-beta.71':
     resolution: {integrity: sha512-d8cRiDt3vXPmAV59YfZxT/ocGgBSZsqjQbhbBmBHAykdQ8xh/9J5DaT8yOOrLIUowG7ZXduWUuCFyNcQCTTMpA==}
 
-  '@stonyx/utils@0.2.3-beta.23':
-    resolution: {integrity: sha512-6LRYN4FA/bYFp3r3/1dUuByC76o3QOMm1n+tot09oi0SRmYyGwgPigAZC0JX2wqkw4Fc9rYyhTLqY8o1g2QOMA==}
+  '@stonyx/utils@0.2.3-beta.25':
+    resolution: {integrity: sha512-g2TvjJIfCfBRbpKWOZDwotAwpkXQ2c4xkRMEao4DZttgt1wYP9nfOEp0V/MkEwjRfq/hSZTQFncG5I36nr6Eng==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -1367,7 +1367,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@stonyx/utils@0.2.3-beta.23': {}
+  '@stonyx/utils@0.2.3-beta.25': {}
 
   '@types/node@25.6.0':
     dependencies:
@@ -1828,7 +1828,7 @@ snapshots:
   stonyx@0.2.3-beta.61:
     dependencies:
       '@stonyx/logs': 1.0.1-beta.16
-      '@stonyx/utils': 0.2.3-beta.23
+      '@stonyx/utils': 0.2.3-beta.25
 
   strnum@2.3.0: {}
 

--- a/src/mysql/connection.ts
+++ b/src/mysql/connection.ts
@@ -9,6 +9,7 @@ interface MysqlConfig {
   connectionLimit?: number;
   migrationsTable?: string;
   migrationsDir?: string;
+  autoMigrate?: boolean;
 }
 
 let pool: Pool | null = null;

--- a/src/mysql/mysql-db.ts
+++ b/src/mysql/mysql-db.ts
@@ -127,7 +127,15 @@ export default class MysqlDB {
     if (pending.length > 0) {
       this.deps.log.db?.(`${pending.length} pending migration(s) found.`);
 
-      const shouldApply = await this.deps.confirm(`${pending.length} pending migration(s) found. Apply now?`);
+      let shouldApply: boolean;
+      if (this.mysqlConfig.autoMigrate === true) {
+        shouldApply = true;
+      } else if (this.mysqlConfig.autoMigrate === false) {
+        shouldApply = false;
+        this.deps.log.warn?.(`autoMigrate is false — skipping ${pending.length} pending migration(s).`);
+      } else {
+        shouldApply = await this.deps.confirm(`${pending.length} pending migration(s) found. Apply now?`);
+      }
 
       if (shouldApply) {
         for (const filename of pending) {
@@ -148,9 +156,17 @@ export default class MysqlDB {
       const modelCount = Object.keys(schemas).length;
 
       if (modelCount > 0) {
-        const shouldGenerate = await this.deps.confirm(
-          `No migrations found but ${modelCount} model(s) detected. Generate and apply initial migration?`
-        );
+        let shouldGenerate: boolean;
+        if (this.mysqlConfig.autoMigrate === true) {
+          shouldGenerate = true;
+        } else if (this.mysqlConfig.autoMigrate === false) {
+          shouldGenerate = false;
+          this.deps.log.warn?.(`autoMigrate is false — skipping initial migration generation for ${modelCount} model(s).`);
+        } else {
+          shouldGenerate = await this.deps.confirm(
+            `No migrations found but ${modelCount} model(s) detected. Generate and apply initial migration?`
+          );
+        }
 
         if (shouldGenerate) {
           const { generateMigration } = await import('./migration-generator.js');

--- a/src/postgres/connection.ts
+++ b/src/postgres/connection.ts
@@ -21,7 +21,7 @@ export async function getPool(pgConfig: PgConfig, extensions: string[] = ['vecto
 
   const { default: pg } = await import('pg');
 
-  const { host, port, user, password, database, connectionLimit, migrationsDir, migrationsTable, ...poolOpts } = pgConfig;
+  const { host, port, user, password, database, connectionLimit, migrationsDir, migrationsTable, autoMigrate, ...poolOpts } = pgConfig;
 
   pool = new pg.Pool({
     host,

--- a/src/postgres/postgres-db.ts
+++ b/src/postgres/postgres-db.ts
@@ -134,7 +134,15 @@ export default class PostgresDB {
     if (pending.length > 0) {
       this.deps.log.db?.(`${pending.length} pending migration(s) found.`);
 
-      const shouldApply = await this.deps.confirm(`${pending.length} pending migration(s) found. Apply now?`);
+      let shouldApply: boolean;
+      if (this.pgConfig.autoMigrate === true) {
+        shouldApply = true;
+      } else if (this.pgConfig.autoMigrate === false) {
+        shouldApply = false;
+        this.deps.log.warn?.(`autoMigrate is false — skipping ${pending.length} pending migration(s).`);
+      } else {
+        shouldApply = await this.deps.confirm(`${pending.length} pending migration(s) found. Apply now?`);
+      }
 
       if (shouldApply) {
         for (const filename of pending) {
@@ -155,9 +163,17 @@ export default class PostgresDB {
       const modelCount = Object.keys(schemas).length;
 
       if (modelCount > 0) {
-        const shouldGenerate = await this.deps.confirm(
-          `No migrations found but ${modelCount} model(s) detected. Generate and apply initial migration?`
-        );
+        let shouldGenerate: boolean;
+        if (this.pgConfig.autoMigrate === true) {
+          shouldGenerate = true;
+        } else if (this.pgConfig.autoMigrate === false) {
+          shouldGenerate = false;
+          this.deps.log.warn?.(`autoMigrate is false — skipping initial migration generation for ${modelCount} model(s).`);
+        } else {
+          shouldGenerate = await this.deps.confirm(
+            `No migrations found but ${modelCount} model(s) detected. Generate and apply initial migration?`
+          );
+        }
 
         if (shouldGenerate) {
           const { generateMigration } = await import('./migration-generator.js');

--- a/src/types/orm-types.ts
+++ b/src/types/orm-types.ts
@@ -18,6 +18,7 @@ export interface OrmMysqlConfig {
   connectionLimit?: number;
   migrationsDir?: string;
   migrationsTable?: string;
+  autoMigrate?: boolean;
   [key: string]: unknown;
 }
 
@@ -30,6 +31,7 @@ export interface OrmPostgresConfig {
   connectionLimit?: number;
   migrationsDir?: string;
   migrationsTable?: string;
+  autoMigrate?: boolean;
   [key: string]: unknown;
 }
 

--- a/test/unit/mysql/mysql-db-startup-test.ts
+++ b/test/unit/mysql/mysql-db-startup-test.ts
@@ -245,6 +245,118 @@ module('[Unit] MysqlDB._rowToRawData — Boolean Coercion', function(hooks) {
   });
 });
 
+module('[Unit] MysqlDB Startup — autoMigrate config (#172)', function(hooks) {
+  hooks.beforeEach(function() {
+    MysqlDB.instance = null;
+  });
+
+  hooks.afterEach(function() {
+    MysqlDB.instance = null;
+    sinon.restore();
+  });
+
+  test('startup() applies pending migrations without confirm when autoMigrate is true', async function(assert) {
+    const deps = createMockDeps({
+      getAppliedMigrations: sinon.stub().resolves(['001.sql']),
+      getMigrationFiles: sinon.stub().resolves(['001.sql', '002.sql', '003.sql']),
+    });
+
+    deps.config.orm.mysql.autoMigrate = true;
+
+    const db = new MysqlDB(deps);
+    db.pool = { execute: sinon.stub().resolves([[]]) };
+
+    await db.startup();
+
+    assert.ok(deps.confirm.notCalled, 'confirm was NOT called');
+    assert.ok(deps.applyMigration.calledTwice, 'applyMigration called for each pending migration');
+    assert.strictEqual(deps.applyMigration.firstCall.args[1], '002.sql', 'first pending migration applied');
+    assert.strictEqual(deps.applyMigration.secondCall.args[1], '003.sql', 'second pending migration applied');
+  });
+
+  test('startup() skips pending migrations with warning when autoMigrate is false', async function(assert) {
+    const deps = createMockDeps({
+      getAppliedMigrations: sinon.stub().resolves([]),
+      getMigrationFiles: sinon.stub().resolves(['001.sql', '002.sql']),
+    });
+
+    deps.config.orm.mysql.autoMigrate = false;
+
+    const db = new MysqlDB(deps);
+    db.pool = { execute: sinon.stub().resolves([[]]) };
+
+    await db.startup();
+
+    assert.ok(deps.confirm.notCalled, 'confirm was NOT called');
+    assert.ok(deps.applyMigration.notCalled, 'applyMigration was NOT called');
+    assert.ok(deps.log.warn.called, 'log.warn was called');
+    const warnMsg = deps.log.warn.args.flat().join(' ');
+    assert.ok(warnMsg.includes('autoMigrate is false'), 'warning mentions autoMigrate is false');
+  });
+
+  test('startup() auto-generates initial migration when autoMigrate is true and no migrations exist', async function(assert) {
+    const deps = createMockDeps({
+      getMigrationFiles: sinon.stub().resolves([]),
+      introspectModels: sinon.stub().returns({
+        user: { table: 'users', columns: { name: 'VARCHAR(255)' }, foreignKeys: {}, memory: true },
+      }),
+    });
+
+    deps.config.orm.mysql.autoMigrate = true;
+
+    const db = new MysqlDB(deps);
+    db.pool = { execute: sinon.stub().resolves([[]]) };
+
+    // generateMigration is a dynamic import that reads global config (not mockable via deps).
+    // We catch its error and verify the behavior up to that point.
+    try {
+      await db.startup();
+    } catch {
+      // Expected: generateMigration throws because global config isn't wired in unit tests
+    }
+
+    assert.ok(deps.confirm.notCalled, 'confirm was NOT called — autoMigrate bypassed the prompt');
+  });
+
+  test('startup() skips initial migration with warning when autoMigrate is false and no migrations exist', async function(assert) {
+    const deps = createMockDeps({
+      getMigrationFiles: sinon.stub().resolves([]),
+      introspectModels: sinon.stub().returns({
+        user: { table: 'users', columns: { name: 'VARCHAR(255)' }, foreignKeys: {}, memory: true },
+      }),
+    });
+
+    deps.config.orm.mysql.autoMigrate = false;
+
+    const db = new MysqlDB(deps);
+    db.pool = { execute: sinon.stub().resolves([[]]) };
+
+    await db.startup();
+
+    assert.ok(deps.confirm.notCalled, 'confirm was NOT called');
+    assert.ok(deps.applyMigration.notCalled, 'applyMigration was NOT called');
+    assert.ok(deps.log.warn.called, 'log.warn was called');
+    const warnMsg = deps.log.warn.args.flat().join(' ');
+    assert.ok(warnMsg.includes('autoMigrate is false'), 'warning mentions autoMigrate is false');
+  });
+
+  test('startup() still calls confirm when autoMigrate is undefined (backward compat)', async function(assert) {
+    const deps = createMockDeps({
+      getAppliedMigrations: sinon.stub().resolves([]),
+      getMigrationFiles: sinon.stub().resolves(['001.sql']),
+      confirm: sinon.stub().resolves(false),
+    });
+
+    // autoMigrate is NOT set — should fall through to confirm()
+    const db = new MysqlDB(deps);
+    db.pool = { execute: sinon.stub().resolves([[]]) };
+
+    await db.startup();
+
+    assert.ok(deps.confirm.calledOnce, 'confirm was called when autoMigrate is undefined');
+  });
+});
+
 module('[Unit] MysqlDB.save — No-op for MySQL', function(hooks) {
   hooks.beforeEach(function() {
     MysqlDB.instance = null;

--- a/test/unit/postgres/postgres-db-startup-test.ts
+++ b/test/unit/postgres/postgres-db-startup-test.ts
@@ -1,0 +1,163 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import PostgresDB from '../../../src/postgres/postgres-db.js';
+
+const { module, test } = QUnit;
+
+function createMockDeps(overrides = {}) {
+  const mockPool = {
+    query: sinon.stub().resolves({ rows: [] }),
+  };
+
+  return {
+    getPool: sinon.stub().resolves(mockPool),
+    closePool: sinon.stub().resolves(),
+    ensureMigrationsTable: sinon.stub().resolves(),
+    getAppliedMigrations: sinon.stub().resolves([]),
+    getMigrationFiles: sinon.stub().resolves([]),
+    applyMigration: sinon.stub().resolves(),
+    parseMigrationFile: sinon.stub().returns({ up: 'CREATE TABLE t (id INT);', down: 'DROP TABLE t;' }),
+    introspectModels: sinon.stub().returns({}),
+    introspectViews: sinon.stub().returns({}),
+    getTopologicalOrder: sinon.stub().returns([]),
+    schemasToSnapshot: sinon.stub().returns({}),
+    loadLatestSnapshot: sinon.stub().resolves({}),
+    detectSchemaDrift: sinon.stub().returns({ hasChanges: false }),
+    buildInsert: sinon.stub().returns({ sql: '', values: [] }),
+    buildUpdate: sinon.stub().returns({ sql: '', values: [] }),
+    buildDelete: sinon.stub().returns({ sql: '', values: [] }),
+    buildSelect: sinon.stub().returns({ sql: '', values: [] }),
+    buildVectorSearch: sinon.stub().returns({ sql: '', values: [] }),
+    buildHybridSearch: sinon.stub().returns({ sql: '', values: [] }),
+    createRecord: sinon.stub().callsFake((_name, data) => ({ id: data.id, __data: data, __relationships: {} })),
+    store: {
+      get: sinon.stub().returns(new Map()),
+      data: new Map(),
+      _memoryResolver: null,
+    },
+    confirm: sinon.stub().resolves(true),
+    readFile: sinon.stub().resolves('-- UP\nCREATE TABLE t (id INT);\n-- DOWN\nDROP TABLE t;'),
+    getPluralName: sinon.stub().callsFake(name => name + 's'),
+    config: { orm: { postgres: { migrationsDir: 'migrations', migrationsTable: '__migrations' } }, rootPath: '/tmp' },
+    log: { db: sinon.stub(), warn: sinon.stub(), error: sinon.stub() },
+    path: {
+      resolve: sinon.stub().returns('/tmp/migrations'),
+      join: sinon.stub().callsFake((...args) => args.join('/')),
+    },
+    _mockPool: mockPool,
+    ...overrides,
+  };
+}
+
+module('[Unit] PostgresDB Startup — autoMigrate config (#172)', function(hooks) {
+  hooks.beforeEach(function() {
+    PostgresDB.instance = undefined;
+  });
+
+  hooks.afterEach(function() {
+    PostgresDB.instance = undefined;
+    sinon.restore();
+  });
+
+  test('startup() applies pending migrations without confirm when autoMigrate is true', async function(assert) {
+    const deps = createMockDeps({
+      getAppliedMigrations: sinon.stub().resolves(['001.sql']),
+      getMigrationFiles: sinon.stub().resolves(['001.sql', '002.sql', '003.sql']),
+    });
+
+    deps.config.orm.postgres.autoMigrate = true;
+
+    const db = new PostgresDB(deps);
+    db.pool = deps._mockPool;
+
+    await db.startup();
+
+    assert.ok(deps.confirm.notCalled, 'confirm was NOT called');
+    assert.ok(deps.applyMigration.calledTwice, 'applyMigration called for each pending migration');
+    assert.strictEqual(deps.applyMigration.firstCall.args[1], '002.sql', 'first pending migration applied');
+    assert.strictEqual(deps.applyMigration.secondCall.args[1], '003.sql', 'second pending migration applied');
+  });
+
+  test('startup() skips pending migrations with warning when autoMigrate is false', async function(assert) {
+    const deps = createMockDeps({
+      getAppliedMigrations: sinon.stub().resolves([]),
+      getMigrationFiles: sinon.stub().resolves(['001.sql', '002.sql']),
+    });
+
+    deps.config.orm.postgres.autoMigrate = false;
+
+    const db = new PostgresDB(deps);
+    db.pool = deps._mockPool;
+
+    await db.startup();
+
+    assert.ok(deps.confirm.notCalled, 'confirm was NOT called');
+    assert.ok(deps.applyMigration.notCalled, 'applyMigration was NOT called');
+    assert.ok(deps.log.warn.called, 'log.warn was called');
+    const warnMsg = deps.log.warn.args.flat().join(' ');
+    assert.ok(warnMsg.includes('autoMigrate is false'), 'warning mentions autoMigrate is false');
+  });
+
+  test('startup() auto-generates initial migration when autoMigrate is true and no migrations exist', async function(assert) {
+    const deps = createMockDeps({
+      getMigrationFiles: sinon.stub().resolves([]),
+      introspectModels: sinon.stub().returns({
+        user: { table: 'users', columns: { name: 'VARCHAR(255)' }, foreignKeys: {}, memory: true },
+      }),
+    });
+
+    deps.config.orm.postgres.autoMigrate = true;
+
+    const db = new PostgresDB(deps);
+    db.pool = deps._mockPool;
+
+    // generateMigration is a dynamic import that reads global config (not mockable via deps).
+    // We catch its error and verify the behavior up to that point.
+    try {
+      await db.startup();
+    } catch {
+      // Expected: generateMigration throws because global config isn't wired in unit tests
+    }
+
+    assert.ok(deps.confirm.notCalled, 'confirm was NOT called — autoMigrate bypassed the prompt');
+  });
+
+  test('startup() skips initial migration with warning when autoMigrate is false and no migrations exist', async function(assert) {
+    const deps = createMockDeps({
+      getMigrationFiles: sinon.stub().resolves([]),
+      introspectModels: sinon.stub().returns({
+        user: { table: 'users', columns: { name: 'VARCHAR(255)' }, foreignKeys: {}, memory: true },
+      }),
+    });
+
+    deps.config.orm.postgres.autoMigrate = false;
+
+    const db = new PostgresDB(deps);
+    db.pool = deps._mockPool;
+
+    await db.startup();
+
+    assert.ok(deps.confirm.notCalled, 'confirm was NOT called');
+    assert.ok(deps.applyMigration.notCalled, 'applyMigration was NOT called');
+    assert.ok(deps.log.warn.called, 'log.warn was called');
+    const warnMsg = deps.log.warn.args.flat().join(' ');
+    assert.ok(warnMsg.includes('autoMigrate is false'), 'warning mentions autoMigrate is false');
+  });
+
+  test('startup() still calls confirm when autoMigrate is undefined (backward compat)', async function(assert) {
+    const deps = createMockDeps({
+      getAppliedMigrations: sinon.stub().resolves([]),
+      getMigrationFiles: sinon.stub().resolves(['001.sql']),
+      confirm: sinon.stub().resolves(false),
+    });
+
+    // autoMigrate is NOT set — should fall through to confirm()
+    const db = new PostgresDB(deps);
+    db.pool = deps._mockPool;
+
+    await db.startup();
+
+    assert.ok(deps.confirm.calledOnce, 'confirm was called when autoMigrate is undefined');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `autoMigrate?: boolean` to `OrmPostgresConfig`, `OrmMysqlConfig`, and `MysqlConfig` interfaces
- Updates `PostgresDB.startup()` and `MysqlDB.startup()` to check `autoMigrate` before calling `confirm()`:
  - `true` = auto-apply migrations without prompt
  - `false` = skip migrations with a warning log
  - `undefined` = call `confirm()` as before (backward compatible)
- Bumps `@stonyx/utils` pnpm override to `0.2.3-beta.25` (Wave 1 non-TTY confirm guard)
- Adds 10 new unit tests (5 per adapter) covering all three `autoMigrate` states

## Test plan
- [x] All 849 tests pass (0 failures, 0 skipped)
- [x] 10 new autoMigrate tests verify: auto-apply, skip-with-warning, auto-generate, skip-generate, and backward-compat confirm fallback
- [x] Existing startup tests unaffected

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)