### PR TITLE
fix: remove destructive clean() from unloadRecord() (#176)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -195,9 +195,9 @@ export default class Store {
   }
 
   /**
-   * Evict a record from the store with full relationship registry cleanup,
-   * WITHOUT calling record.clean(). This preserves the caller's reference
-   * to the returned record (used by memory:false post-persist eviction).
+   * Evict a record from the store with full relationship registry cleanup.
+   * The caller retains its reference to the returned record, which is the
+   * contract memory:false post-persist eviction relies on.
    *
    * @param registryId - The ID used when the record's relationships were
    *   registered. For SQL models with pending IDs, this is the original

--- a/src/store.ts
+++ b/src/store.ts
@@ -258,7 +258,6 @@ export default class Store {
       this._removeFromHasManyArrays(modelName, recordId, visited);
       this._nullifyBelongsToReferences(modelName, recordId, visited);
       this._cleanupRelationshipRegistries(modelName, recordId);
-      recordToUnload.clean();
 
       this.data.get(modelName)?.delete(recordId as string | number);
     }

--- a/test/unit/unload-held-reference-test.ts
+++ b/test/unit/unload-held-reference-test.ts
@@ -1,0 +1,80 @@
+// @ts-nocheck
+import QUnit from 'qunit';
+import { createRecord, store, relationships } from '@stonyx/orm';
+
+const { module, test } = QUnit;
+
+module('[Unit] Store | unloadRecord held-reference corruption (#176)', function(hooks) {
+  const clearStores = function() {
+    const models = ['owner', 'animal', 'trait', 'category', 'phone-number'];
+    for (const model of models) {
+      const modelStore = store.get(model);
+      if (modelStore) modelStore.clear();
+    }
+
+    relationships.get('hasMany')?.clear();
+    relationships.get('belongsTo')?.clear();
+    relationships.get('pending')?.clear();
+    relationships.get('pendingBelongsTo')?.clear();
+  };
+
+  hooks.beforeEach(clearStores);
+  hooks.afterEach(clearStores);
+
+  module('held references survive unloadRecord', function() {
+    test('record is removed from store after unloadRecord', function(assert) {
+      createRecord('animal', { id: 1, type: 'dog', age: 3, size: 'large' }, { serialize: false });
+
+      store.unloadRecord('animal', 1);
+
+      assert.strictEqual(store.get('animal', 1), undefined, 'store.get returns undefined after unload');
+    });
+
+    test('held reference preserves __data after unloadRecord', function(assert) {
+      const heldRef = createRecord('animal', { id: 1, type: 'dog', age: 3, size: 'large' }, { serialize: false });
+
+      store.unloadRecord('animal', 1);
+
+      assert.notStrictEqual(heldRef.__data, undefined, '__data is preserved on held reference');
+    });
+
+    test('held reference preserves __model after unloadRecord', function(assert) {
+      const heldRef = createRecord('animal', { id: 1, type: 'dog', age: 3, size: 'large' }, { serialize: false });
+
+      store.unloadRecord('animal', 1);
+
+      assert.notStrictEqual(heldRef.__model, undefined, '__model is preserved on held reference');
+    });
+
+    test('held reference serialize() does not throw after unloadRecord', function(assert) {
+      const heldRef = createRecord('animal', { id: 1, type: 'dog', age: 3, size: 'large' }, { serialize: false });
+
+      store.unloadRecord('animal', 1);
+
+      const result = heldRef.serialize();
+      assert.ok(result, 'serialize() does not throw after unload');
+      assert.strictEqual(typeof result, 'object', 'serialize() returns a valid object');
+    });
+  });
+
+  module('held child references survive unloadRecord with includeChildren', function() {
+    test('held child reference preserves __data after parent unload with includeChildren', function(assert) {
+      createRecord('owner', { id: 'owner-176-1', gender: 'male', age: 30 }, { serialize: false });
+      const heldChild = createRecord('animal', { id: 1, type: 'dog', age: 3, size: 'large', owner: 'owner-176-1' }, { serialize: false });
+
+      store.unloadRecord('owner', 'owner-176-1', { includeChildren: true });
+
+      assert.notStrictEqual(heldChild.__data, undefined, 'child __data is preserved after parent unload with includeChildren');
+    });
+
+    test('held child reference serialize() does not throw after parent unload with includeChildren', function(assert) {
+      createRecord('owner', { id: 'owner-176-2', gender: 'female', age: 25 }, { serialize: false });
+      const heldChild = createRecord('animal', { id: 2, type: 'cat', age: 2, size: 'small', owner: 'owner-176-2' }, { serialize: false });
+
+      store.unloadRecord('owner', 'owner-176-2', { includeChildren: true });
+
+      const result = heldChild.serialize();
+      assert.ok(result, 'child serialize() does not throw after parent unload with includeChildren');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `Store.unloadRecord()` called `record.clean()` which destructively strips all own properties via `delete this[key]`, corrupting any other code path holding a reference to the same record instance
- Removed the `clean()` call from `unloadRecord()` — the `modelStore.delete()` on the next line already handles store removal
- `Store.evictRecord()` already uses this exact pattern (no `clean()` call), proving it is the correct approach

Closes #176

## Test plan

- [x] `store.get('animal', 1)` returns `undefined` after `store.unloadRecord('animal', 1)` — record is removed from store
- [x] `heldRef.__data` is not `undefined` after unload — properties preserved on held reference
- [x] `heldRef.__model` is not `undefined` after unload — model reference preserved
- [x] `heldRef.serialize()` does not throw after unload — method still callable
- [x] `typeof heldRef.serialize()` equals `'object'` — returns valid data
- [x] Held child reference `__data` is not `undefined` after `unloadRecord(parent, id, { includeChildren: true })` — child references also preserved
- [x] Held child reference `serialize()` does not throw after parent unload with includeChildren
- [x] All 855 existing tests pass (including `record-tojson-cleaned-test.ts` which calls `clean()` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)